### PR TITLE
Export Connection.Transport for use on Appengine

### DIFF
--- a/compatibility_1_0.go
+++ b/compatibility_1_0.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Cancel the request - doesn't work under < go 1.1
-func cancelRequest(tr *http.Transport, req *http.Request) {
+func cancelRequest(transport http.RoundTripper, req *http.Request) {
 	log.Printf("Tried to cancel a request but couldn't - recompile with go 1.1")
 }
 

--- a/compatibility_1_1.go
+++ b/compatibility_1_1.go
@@ -10,8 +10,12 @@ import (
 )
 
 // Cancel the request
-func cancelRequest(tr *http.Transport, req *http.Request) {
-	tr.CancelRequest(req)
+func cancelRequest(transport http.RoundTripper, req *http.Request) {
+	if tr, ok := transport.(interface {
+		CancelRequest(*http.Request)
+	}); ok {
+		tr.CancelRequest(req)
+	}
 }
 
 // Reset a timer


### PR DESCRIPTION
Some environments, such as Google Appengine, have restrictions on sockets.
An http transport can be used with Connection to interface to the custom
backend:

  import (
      "appengine/urlfetch"
      "fmt"
      "github.com/ncw/swift"
  )

  func handler(w http.ResponseWriter, r *http.Request) {
      ctx := appengine.NewContext(r)
      c := swift.Connection{
          UserName:  "user",
          ApiKey:    "key",
          AuthUrl:   "auth_url",
          Transport: urlfetch.Transport{Context: ctx},
      }
      err := c.Authenticate()
      if err != nil {
          panic(err)
      }
      fmt.Fprintf(w, "Authenticate OK")
  }

Fixes #5
Original fix by @vmihailenko
