### PR TITLE
Expose Auth Token and Storage

### DIFF
--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -316,10 +316,10 @@ func TestInternalAuthenticate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c.storageUrl != PROXY_URL {
+	if c.StorageUrl != PROXY_URL {
 		t.Error("Bad storage url")
 	}
-	if c.authToken != AUTH_TOKEN {
+	if c.AuthToken != AUTH_TOKEN {
 		t.Error("Bad auth token")
 	}
 	if !c.Authenticated() {


### PR DESCRIPTION
Add ability to set Storage URL and Auth Token, to enable a user to cache them outside of the Swift client.
