### PR TITLE
Fix indefinite hang on Write() of object created through ObjectCreate().

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -985,6 +985,9 @@ type ObjectCreateFile struct {
 
 // Write bytes to the object - see io.Writer
 func (file *ObjectCreateFile) Write(p []byte) (n int, err error) {
+	if file.err != nil {
+		return 0, file.err
+	}
 	if file.checkHash {
 		_, _ = file.hash.Write(p)
 	}


### PR DESCRIPTION
In the current code, when "PUT" request of a ObjectCreate() fails, or there is
subsequent socket disconnection, the reader pipe is not necessarily closed.
This causes a Write() call to block forever trying to write to 'pipeWriter'.

We've experienced this in at least one scenario: when Swift detects quota limit
is reached, the ObjectCreate PUT returns a 413 "Too Large Object" error.

One potential fix for this issue would be to close the pipeReader, causing the
next Write() call to fail with ErrClosedPipe. This has the disadvantage that the
user does not receive the true reason for the Write to fail.

Instead, this patch checks the status of file.err before attempting to make the
Write() call. It returns the Swift server error back to the user.
