### PR TITLE
Add a test Swift server and run the test suite against it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
   - tip
 
 script:
-  - go test -run Internal
+  - go test

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ The `rs` sub project contains a wrapper for the Rackspace specific CDN Managemen
 Testing
 -------
 
-To run the tests you'll need access to an Openstack Swift server or a
-Rackspace Cloud files account.
+To run the tests you can either use an embedded fake Swift server
+either use a real Openstack Swift server or a Rackspace Cloud files account.
 
-Set these environment variables before running the tests
+When using a real Swift server, you need to set these environment variables
+before running the tests
 
     export SWIFT_API_USER='user'
     export SWIFT_API_KEY='key'

--- a/swifttest/server.go
+++ b/swifttest/server.go
@@ -1,0 +1,806 @@
+// This implements a very basic Swift server
+// Everything is stored in memory
+//
+// This comes from the https://github.com/mitchellh/goamz
+// and was adapted for Swift
+//
+package swifttest
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ncw/swift"
+)
+
+const (
+	DEBUG        = false
+)
+
+type SwiftServer struct {
+	t          *testing.T
+	listener   net.Listener
+	url        string
+	reqId      int
+	mu         sync.Mutex
+	containers map[string]*container
+	accounts   map[string]*account
+	sessions   map[string]*session
+}
+
+// The Folder type represents a container stored in an account
+type Folder struct {
+    Count        int `json:"count"`
+    Bytes        int `json:"bytes"`
+    Name         string  `json:"name"`
+}
+
+// The Key type represents an item stored in an container.
+type Key struct {
+    Key          string `json:"name"`
+    LastModified string `json:"last_modified"`
+    Size         int64  `json:"bytes"`
+    // ETag gives the hex-encoded MD5 sum of the contents,
+    // surrounded with double-quotes.
+    ETag         string `json:"hash"`
+    ContentType  string `json:"content_type"`
+    // Owner        Owner
+}
+
+type Subdir struct {
+	Subdir       string `json:"subdir"`
+}
+
+type swiftError struct {
+	statusCode    int
+	Code          string
+	Message       string
+}
+
+type action struct {
+	srv   *SwiftServer
+	w     http.ResponseWriter
+	req   *http.Request
+	reqId string
+	user  *account
+}
+
+type session struct {
+	username string
+}
+
+type metadata struct {
+	meta     http.Header // metadata to return with requests.
+}
+
+type account struct {
+	swift.Account
+	metadata
+	password string
+}
+
+type object struct {
+	metadata
+	name         string
+	mtime        time.Time
+	checksum     []byte      // also held as ETag in meta.
+	data         []byte
+    content_type string
+}
+
+type container struct {
+	metadata
+	name    string
+	ctime   time.Time
+	objects map[string]*object
+	bytes   int
+}
+
+// A resource encapsulates the subject of an HTTP request.
+// The resource referred to may or may not exist
+// when the request is made.
+type resource interface {
+	put(a *action) interface{}
+	get(a *action) interface{}
+	post(a *action) interface{}
+	delete(a *action) interface{}
+	copy(a *action) interface{}
+}
+
+type objectResource struct {
+	name       string
+	version    string
+	container *container // always non-nil.
+	object    *object // may be nil.
+}
+
+type containerResource struct {
+	name   string
+	container *container // non-nil if the container already exists.
+}
+
+var responseParams = map[string]bool{
+	"content-type":        true,
+	"content-language":    true,
+	"expires":             true,
+	"cache-control":       true,
+	"content-disposition": true,
+	"content-encoding":    true,
+}
+
+func fatalf(code int, codeStr string, errf string, a ...interface{}) {
+	panic(&swiftError{
+		statusCode: code,
+		Code:       codeStr,
+		Message:    fmt.Sprintf(errf, a...),
+	})
+}
+
+func (m metadata) setMetadata(a *action, resource string) {
+	for key, values := range a.req.Header {
+		key = http.CanonicalHeaderKey(key)
+		if metaHeaders[key] || strings.HasPrefix(key, "X-" + strings.Title(resource) + "-Meta-") {
+			if values[0] != "" || resource == "object" {
+				m.meta[key] = values
+			} else {
+				m.meta.Del(key)
+			}
+		}
+	}
+}
+
+func (m metadata) getMetadata(a *action) {
+	h := a.w.Header()
+	for name, d := range m.meta {
+		h[name] = d
+	}
+}
+
+// GET on a bucket lists the objects in the bucket.
+func (r containerResource) get(a *action) interface{} {
+	if r.container == nil {
+		fatalf(404, "NoSuchContainer", "The specified container does not exist")
+	}
+
+	delimiter := a.req.Form.Get("delimiter")
+	marker := a.req.Form.Get("marker")
+	prefix := a.req.Form.Get("prefix")
+	format := a.req.URL.Query().Get("format")
+	parent := a.req.Form.Get("path")
+
+	a.w.Header().Set("X-Container-Bytes-Used", strconv.Itoa(r.container.bytes))
+	a.w.Header().Set("X-Container-Object-Count", strconv.Itoa(len(r.container.objects)))
+	r.container.getMetadata(a)
+
+	if a.req.Method == "HEAD" {
+		return nil
+	}
+
+	var tmp orderedObjects
+	var resp []interface{} = make([]interface{}, 0)
+
+	// first get all matching objects and arrange them in alphabetical order.
+	for _, obj := range r.container.objects {
+		if strings.HasPrefix(obj.name, prefix) {
+			tmp = append(tmp, obj)
+		}
+	}
+	sort.Sort(tmp)
+
+	var prefixes []string
+	for _, obj := range tmp {
+		if !strings.HasPrefix(obj.name, prefix) {
+			continue
+		}
+
+		isPrefix := false
+		name := obj.name
+		if parent != "" {
+			if path.Dir(obj.name) != path.Clean(parent) {
+				continue
+			}
+		} else if delimiter != "" {
+			if i := strings.Index(obj.name[len(prefix):], delimiter); i >= 0 {
+				name = obj.name[:len(prefix)+i+len(delimiter)]
+				if prefixes != nil && prefixes[len(prefixes)-1] == name {
+					continue
+				}
+				isPrefix = true
+			}
+		}
+
+		if name <= marker {
+			continue
+		}
+
+		if isPrefix {
+			prefixes = append(prefixes, name)
+			resp = append(resp, Subdir{
+				Subdir: name,
+			})
+		} else {
+			if format == "json" {
+				resp = append(resp, obj.Key())
+			} else {
+				a.w.Write([]byte(obj.name + "\n"))			
+			}
+		}
+	}
+
+	if format == "json" {
+		return resp;
+	} else {
+		return nil
+	}
+}
+
+// orderedContainers holds a slice of containers that can be sorted
+// by name.
+type orderedContainers []*container
+
+func (s orderedContainers) Len() int {
+	return len(s)
+}
+func (s orderedContainers) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s orderedContainers) Less(i, j int) bool {
+	return s[i].name < s[j].name
+}
+
+func (r containerResource) delete(a *action) interface{} {
+	b := r.container
+	if b == nil {
+		fatalf(404, "NoSuchContainer", "The specified container does not exist")
+	}
+	if len(b.objects) > 0 {
+		fatalf(409, "Conflict", "The container you tried to delete is not empty")
+	}
+	delete(a.srv.containers, b.name)
+	a.user.Containers--
+	return nil
+}
+
+func (r containerResource) put(a *action) interface{} {
+	if a.req.URL.Query().Get("extract-archive") != "" {
+		fatalf(403, "Operation forbidden", "Bulk upload is not supported")
+	}
+
+	var created bool
+	if r.container == nil {
+		if !validContainerName(r.name) {
+			fatalf(400, "InvalidContainerName", "The specified container is not valid")
+		}
+		r.container = &container{
+			name: r.name,
+			objects: make(map[string]*object),
+			metadata: metadata{
+				meta: make(http.Header),
+			},
+		}
+		r.container.setMetadata(a, "container")
+		a.srv.containers[r.name] = r.container
+		a.user.Containers++
+		created = true
+	}
+	if !created {
+		fatalf(409, "ContainerAlreadyOwnedByYou", "Your previous request to create the named container succeeded and you already own it.")
+	}
+	return nil
+}
+
+func (r containerResource) post(a *action) interface{} {
+	if r.container == nil {
+		fatalf(400, "Method", "The resource could not be found.")
+	} else {
+		r.container.setMetadata(a, "container")
+		a.w.WriteHeader(201)
+		jsonMarshal(a.w, Folder{
+			Count: len(r.container.objects),
+			Bytes: r.container.bytes,
+			Name: r.container.name,
+		})
+	}
+	return nil
+}
+
+func (containerResource) copy(a *action) interface{} { return notAllowed() }
+
+// validContainerName returns whether name is a valid bucket name.
+// Here are the rules, from:
+// http://docs.openstack.org/api/openstack-object-storage/1.0/content/ch_object-storage-dev-api-storage.html
+//
+// Container names cannot exceed 256 bytes and cannot contain the / character.
+//
+func validContainerName(name string) bool {
+	if len(name) == 0 || len(name) > 256 {
+		return false
+	}
+	for _, r := range name {
+		switch {
+		case r == '/':
+			return false
+		default:
+		}
+	}
+	return true
+}
+
+// orderedObjects holds a slice of objects that can be sorted
+// by name.
+type orderedObjects []*object
+
+func (s orderedObjects) Len() int {
+	return len(s)
+}
+func (s orderedObjects) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s orderedObjects) Less(i, j int) bool {
+	return s[i].name < s[j].name
+}
+
+func (obj *object) Key() Key {
+	return Key{
+		Key:          obj.name,
+		LastModified: obj.mtime.Format("2006-01-02T15:04:05"),
+		Size:         int64(len(obj.data)),
+		ETag:         fmt.Sprintf("%x", obj.checksum),
+		ContentType:  obj.content_type,
+	}
+}
+
+var metaHeaders = map[string]bool{
+	"Content-Type":        true,
+	"Content-Encoding":    true,
+	"Content-Disposition": true,
+}
+
+var rangeRegexp = regexp.MustCompile("([0-9])*-([0-9])*")
+
+// GET on an object gets the contents of the object.
+func (objr objectResource) get(a *action) interface{} {
+	obj := objr.object
+	if obj == nil {
+		fatalf(404, "Not Found", "The resource could not be found.")
+	}
+	h := a.w.Header()
+	// add metadata
+	obj.getMetadata(a)
+
+	var (
+		start int
+		end   int = len(obj.data)
+	)
+	if r := a.req.Header.Get("Range"); r != "" {
+		m := rangeRegexp.FindStringSubmatch(r)
+		if m[1] != "" {
+			start, _ = strconv.Atoi(m[1])
+		}
+		if m[2] != "" {
+			end, _ = strconv.Atoi(m[2])
+		}
+	}
+
+	h.Set("Content-Length", fmt.Sprint(len(obj.data)))
+	h.Set("ETag", hex.EncodeToString(obj.checksum))
+	h.Set("Last-Modified", obj.mtime.Format(http.TimeFormat))
+
+	if a.req.Method == "HEAD" {
+		return nil
+	}
+
+	// TODO avoid holding the lock when writing data.
+	_, err := a.w.Write(obj.data[start:end])
+	if err != nil {
+		// we can't do much except just log the fact.
+		log.Printf("error writing data: %v", err)
+	}
+	return nil
+}
+
+// PUT on an object creates the object.
+func (objr objectResource) put(a *action) interface{} {
+	var expectHash []byte
+	if c := a.req.Header.Get("ETag"); c != "" {
+		var err error
+		expectHash, err = hex.DecodeString(c)
+		if err != nil || len(expectHash) != md5.Size {
+			fatalf(400, "InvalidDigest", "The ETag you specified was invalid")
+		}
+	}
+	sum := md5.New()
+	// TODO avoid holding lock while reading data.
+	data, err := ioutil.ReadAll(io.TeeReader(a.req.Body, sum))
+	if err != nil {
+		fatalf(400, "TODO", "read error")
+	}
+	gotHash := sum.Sum(nil)
+	if expectHash != nil && bytes.Compare(gotHash, expectHash) != 0 {
+		fatalf(422, "Bad ETag", "The ETag you specified did not match what we received")
+	}
+	if a.req.ContentLength >= 0 && int64(len(data)) != a.req.ContentLength {
+		fatalf(400, "IncompleteBody", "You did not provide the number of bytes specified by the Content-Length HTTP header")
+	}
+
+	// TODO is this correct, or should we erase all previous metadata?
+	obj := objr.object
+	if obj == nil {
+		obj = &object{
+			name: objr.name,
+			metadata: metadata{
+				meta: make(http.Header),
+			},
+		}
+		a.user.Objects++
+	} else {
+		objr.container.bytes -= len(obj.data)
+		a.user.BytesUsed -= int64(len(obj.data))
+	}
+
+	var content_type string
+	if content_type = a.req.Header.Get("Content-Type"); content_type == "" {
+		content_type := mime.TypeByExtension(obj.name)
+		if content_type == "" {
+			content_type = "application/octet-stream"
+		}
+	}
+
+	// PUT request has been successful - save data and metadata
+	obj.setMetadata(a, "object")
+	obj.content_type = content_type
+	obj.data = data
+	obj.checksum = gotHash
+	obj.mtime = time.Now().UTC()
+	objr.container.objects[objr.name] = obj
+	objr.container.bytes += len(data)
+	a.user.BytesUsed += int64(len(data))
+
+	h := a.w.Header()
+	h.Set("ETag", hex.EncodeToString(obj.checksum))
+
+	return nil
+}
+
+func (objr objectResource) delete(a *action) interface{} {
+	if objr.object == nil {
+		fatalf(404, "NoSuchKey", "The specified key does not exist.")
+	}
+
+	objr.container.bytes -= len(objr.object.data)
+	a.user.BytesUsed -= int64(len(objr.object.data))
+	delete(objr.container.objects, objr.name)
+	a.user.Objects--
+	return nil
+}
+
+func (objr objectResource) post(a *action) interface{} {
+	obj := objr.object
+	obj.setMetadata(a, "object")
+	return nil
+}
+
+func (objr objectResource) copy(a *action) interface{} {
+	obj := objr.object
+	destination := a.req.Header.Get("Destination")
+	if destination == "" {
+		fatalf(400, "Bad Request", "You must provide a Destination header")
+	}
+
+	var (
+		obj2 *object
+		objr2 objectResource
+	)
+
+	destURL, _ := url.Parse("/v1/AUTH_tk/" + destination)
+	r := a.srv.resourceForURL(destURL)
+	switch t := r.(type) {
+	case objectResource:
+		objr2 = t
+		if objr2.object == nil {
+			obj2 = &object{
+				name: objr2.name,
+				metadata: metadata{
+					meta: make(http.Header),
+				},
+			}
+			a.user.Objects++
+		} else {
+			obj2 = objr2.object
+			objr2.container.bytes -= len(obj2.data)
+			a.user.BytesUsed -= int64(len(obj2.data))
+		}
+	default:
+		fatalf(400, "Bad Request", "Destination must point to a valid object path")
+	}
+
+	obj2.content_type = obj.content_type
+	obj2.data = obj.data
+	obj2.checksum = obj.checksum
+	obj2.mtime = time.Now()
+	objr2.container.objects[objr2.name] = obj2
+	objr2.container.bytes += len(obj.data)
+	a.user.BytesUsed += int64(len(obj.data))
+
+	for key, values := range obj.metadata.meta {
+		obj2.metadata.meta[key] = values
+	}
+	obj2.setMetadata(a, "object")
+
+	return nil
+}
+
+func (s *SwiftServer) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	// ignore error from ParseForm as it's usually spurious.
+	req.ParseForm()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if DEBUG {
+		log.Printf("swifttest %q %q", req.Method, req.URL)
+	}
+	a := &action{
+		srv:   s,
+		w:     w,
+		req:   req,
+		reqId: fmt.Sprintf("%09X", s.reqId),
+	}
+	s.reqId++
+
+	var r resource
+	defer func() {
+		switch err := recover().(type) {
+		case *swiftError:
+			w.Header().Set("Content-Type", `text/plain; charset=utf-8`)
+			http.Error(w, err.Message, err.statusCode)
+		case nil:
+		default:
+			panic(err)
+		}
+	}()
+
+	var resp interface{}
+
+	if req.URL.String() == "/v1.0" {
+		username := req.Header.Get("x-auth-user") 
+		key := req.Header.Get("x-auth-key")
+		if acct, ok := s.accounts[username]; ok {
+			if acct.password == key {
+				r := make([]byte, 16)
+			    _, _ = rand.Read(r)
+			    id := fmt.Sprintf("%X", r)
+				w.Header().Set("X-Storage-Url", s.url + "/v1/AUTH_" + username)
+				w.Header().Set("X-Auth-Token", "AUTH_tk" + string(id))
+				w.Header().Set("X-Storage-Token", "AUTH_tk" + string(id))
+				s.sessions[id] = &session{
+					username: username,
+				}
+				return
+			}
+		}
+		panic(notAuthorized())
+	}
+
+	key := req.Header.Get("x-auth-token")
+	session, ok := s.sessions[key[7:]]
+	if !ok {
+		panic(notAuthorized())
+	}
+
+	a.user = s.accounts[session.username]
+
+	r = s.resourceForURL(req.URL)
+
+	switch req.Method {
+	case "PUT":
+		resp = r.put(a)
+	case "GET", "HEAD":
+		resp = r.get(a)
+	case "DELETE":
+		resp = r.delete(a)
+	case "POST":
+		resp = r.post(a)
+	case "COPY":
+		resp = r.copy(a)
+	default:
+		fatalf(400, "MethodNotAllowed", "unknown http request method %q", req.Method)
+	}
+
+	content_type := req.Header.Get("Content-Type")
+	if resp != nil && req.Method != "HEAD" {
+		if strings.HasPrefix(content_type, "application/json") ||
+		   req.URL.Query().Get("format") == "json" {
+			jsonMarshal(w, resp)
+		} else {
+			switch r := resp.(type) {
+			case string:
+				w.Write([]byte(r))
+			default:
+				w.Write(resp.([]byte))
+			}
+		}
+	}
+}
+
+func jsonMarshal(w io.Writer, x interface{}) {
+	if err := json.NewEncoder(w).Encode(x); err != nil {
+		panic(fmt.Errorf("error marshalling %#v: %v", x, err))
+	}
+}
+
+var pathRegexp = regexp.MustCompile("/v1/AUTH_[a-zA-Z0-9]+(/([^/]+)(/(.*))?)?")
+
+// resourceForURL returns a resource object for the given URL.
+func (srv *SwiftServer) resourceForURL(u *url.URL) (r resource) {
+	m := pathRegexp.FindStringSubmatch(u.Path)
+	if m == nil {
+		fatalf(404, "InvalidURI", "Couldn't parse the specified URI")
+	}
+	containerName := m[2]
+	objectName := m[4]
+	if containerName == "" {
+		return rootResource{}
+	}
+	b := containerResource{
+		name:      containerName,
+		container: srv.containers[containerName],
+	}
+
+	if objectName == "" {
+		return b
+	}
+
+	if b.container == nil {
+		fatalf(404, "NoSuchContainer", "The specified container does not exist")
+	}
+
+	objr := objectResource{
+		name:      objectName,
+		version:   u.Query().Get("versionId"),
+		container: b.container,
+	}
+
+	if obj := objr.container.objects[objr.name]; obj != nil {
+		objr.object = obj
+	}
+	return objr
+}
+
+// nullResource has error stubs for all resource methods.
+type nullResource struct{}
+
+func notAllowed() interface{} {
+	fatalf(400, "MethodNotAllowed", "The specified method is not allowed against this resource")
+	return nil
+}
+
+func notAuthorized() interface{} {
+	fatalf(401, "Unauthorized", "This server could not verify that you are authorized to access the document you requested.")
+	return nil
+}
+
+func (nullResource) put(a *action) interface{}    { return notAllowed() }
+func (nullResource) get(a *action) interface{}    { return notAllowed() }
+func (nullResource) post(a *action) interface{}   { return notAllowed() }
+func (nullResource) delete(a *action) interface{} { return notAllowed() }
+func (nullResource) copy(a *action) interface{}   { return notAllowed() }
+
+type rootResource struct{}
+
+func (rootResource) put(a *action) interface{}    { return notAllowed() }
+func (rootResource) get(a *action) interface{} {
+	marker := a.req.Form.Get("marker")
+	prefix := a.req.Form.Get("prefix")
+	format := a.req.URL.Query().Get("format")
+
+	h := a.w.Header()
+
+	h.Set("X-Account-Bytes-Used", strconv.Itoa(int(a.user.BytesUsed)))
+	h.Set("X-Account-Container-Count", strconv.Itoa(int(a.user.Containers)))
+	h.Set("X-Account-Object-Count", strconv.Itoa(int(a.user.Objects)))
+
+	// add metadata
+	a.user.metadata.getMetadata(a)
+
+	if a.req.Method == "HEAD" {
+		return nil
+	}
+
+	var tmp orderedContainers
+	// first get all matching objects and arrange them in alphabetical order.
+	for _, container := range a.srv.containers {
+		if strings.HasPrefix(container.name, prefix) {
+			tmp = append(tmp, container)
+		}
+	}
+	sort.Sort(tmp)
+
+	resp := make([]Folder, 0)
+	for _, container := range tmp {
+		if container.name <= marker {
+			continue
+		}
+		if format == "json" {
+			resp = append(resp, Folder{
+				Count: len(container.objects),
+				Bytes: container.bytes,
+				Name: container.name,
+			})
+		} else {
+			a.w.Write([]byte(container.name + "\n"))
+		}
+	}
+
+	if format == "json" {
+		return resp;
+	} else {
+		return nil
+	}
+}
+
+func (r rootResource) post(a *action) interface{} {
+	a.user.metadata.setMetadata(a, "account")
+	return nil
+}
+
+func (rootResource) delete(a *action) interface{} {
+	if a.req.URL.Query().Get("bulk-delete") == "1" {
+		fatalf(403, "Operation forbidden", "Bulk delete is not supported")
+	}
+
+	return notAllowed()
+}
+
+func (rootResource) copy(a *action) interface{} { return notAllowed() }
+
+func NewSwiftServer(address string) (*SwiftServer, error) {
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("cannot listen on %s: %v", address, err)
+	}
+
+	server := &SwiftServer{
+		listener:   l,
+		url:        "http://" + l.Addr().String(),
+		containers: make(map[string]*container),
+		accounts:   make(map[string]*account),
+		sessions:   make(map[string]*session),
+	}
+
+    server.accounts["swifttest"] = &account{
+    	password: "swifttest",
+		metadata: metadata{
+			meta: make(http.Header),
+		},
+    }
+
+	go http.Serve(l, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		server.serveHTTP(w, req)
+	}))
+
+	return server, nil
+}
+
+func (srv SwiftServer) Close() {
+	srv.listener.Close()
+}


### PR DESCRIPTION
This pull request implements a Swift server for testing purposes.

It is far from complete but is able to run the test suite. It is used when no environment variables for a real Swift server have been found.

This was first implemented when adding a Swift backend for Aptly (https://github.com/smira/aptly) - using your cool library, thanks ! - and be able to run the Aptly test suite without access to a real Swift server.
I thought that it might be useful to add it directly to your library.