### PR TITLE
Retry when getting an EOF on HEAD/GET requests because of a Golang bug

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -465,6 +465,10 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 		req.Header.Add("X-Auth-Token", authToken)
 		resp, err = c.doTimeoutRequest(timer, req)
 		if err != nil {
+			if p.Operation == "HEAD" || p.Operation == "GET" {
+				retries--;
+				continue
+			}
 			return
 		}
 		// Check to see if token has expired


### PR DESCRIPTION
When running a 30 minutes testsuite (https://github.com/lebauce/distribution), I faced a weird issue : I sometimes got a url.Error : "Head https://my.swift.server/v1/AUTH_abcdb3abcda34a1c8d618164d99eb53e/test/myobject : EOF". I'm using the 1.4.2 version of Go.

The issue seems to be in the `net/http` library and is described in both tickets :
https://github.com/golang/go/issues/4677
https://github.com/golang/go/issues/8946

A fix on `net/http` is under review : https://golang.org/cl/3210

A fix for this problem is simply to send the request again when the request was a HEAD or a GET