### PR TITLE
Fix v3AuthResponse parsing for roles with links

### DIFF
--- a/auth_v3.go
+++ b/auth_v3.go
@@ -71,7 +71,12 @@ type v3AuthResponse struct {
 	Token struct {
 		Expires_At, Issued_At string
 		Methods               []string
-		Roles                 []map[string]string
+		Roles                 []struct {
+			Id, Name string
+			Links    struct {
+				Self string
+			}
+		}
 
 		Project struct {
 			Domain struct {


### PR DESCRIPTION
This avoids a `panic: json: cannot unmarshal object into Go value of type string` when the v3 response contains roles with links.

Which according to http://specs.openstack.org/openstack/keystone-specs/api/v3/identity-api-v3.html#roles-v3-roles can be a thing.