### PR TITLE
Use custom User-Agent Header in all requests

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -156,6 +156,7 @@ func (auth *v2Auth) Request(c *Connection) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
 	return req, nil
 }
 

--- a/auth_v3.go
+++ b/auth_v3.go
@@ -177,6 +177,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
 	return req, nil
 }
 

--- a/swift.go
+++ b/swift.go
@@ -463,7 +463,7 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 				req.Header.Add(k, v)
 			}
 		}
-		req.Header.Add("User-Agent", DefaultUserAgent)
+		req.Header.Add("User-Agent", c.UserAgent)
 		req.Header.Add("X-Auth-Token", authToken)
 		resp, err = c.doTimeoutRequest(timer, req)
 		if err != nil {


### PR DESCRIPTION
This can greatly help when debugging token stampedes where a misbehaving client is generating tokens in a tight loop (for whatever reason).