### PR TITLE
Fix endless loop after authenticate when the swift server is not reachable

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -467,11 +467,12 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 		req.Header.Add("X-Auth-Token", authToken)
 		resp, err = c.doTimeoutRequest(timer, req)
 		if err != nil {
-			if p.Operation == "HEAD" || p.Operation == "GET" {
+			if (p.Operation == "HEAD" || p.Operation == "GET") && retries > 0 {
 				retries--
 				continue
 			}
-			return
+			_ = resp.Body.Close()
+			return nil, nil, err
 		}
 		// Check to see if token has expired
 		if resp.StatusCode == 401 && retries > 0 {

--- a/swift.go
+++ b/swift.go
@@ -471,7 +471,6 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 				retries--
 				continue
 			}
-			_ = resp.Body.Close()
 			return nil, nil, err
 		}
 		// Check to see if token has expired


### PR DESCRIPTION
This avoids a endless loop when getting an error from doTimeoutRequest an method call