### PR TITLE
Avoid unnecessary retries on authentication fail

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -433,8 +433,9 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 	var req *http.Request
 	for {
 		var authToken string
-		targetUrl, authToken, err = c.getUrlAndAuthToken(targetUrl, p.OnReAuth)
-
+		if targetUrl, authToken, err = c.getUrlAndAuthToken(targetUrl, p.OnReAuth); err != nil {
+			return //authentication failure
+		}
 		var URL *url.URL
 		URL, err = url.Parse(targetUrl)
 		if err != nil {


### PR DESCRIPTION
I just noticed that the a misconfigured client (wrong password) tries 8 times to get a token before failing because the error of  `getUrlAndAuthToken` was not considered in `Call`.

This does not happen when explicitly calling `c.Authenticate()` and checking the return value but in my case I'm trying to reuse an existing token and start with swift api calls right away.