### PR TITLE
allow to authenticate into a tenant/project in a different domain

### DIFF
--- a/auth_v3.go
+++ b/auth_v3.go
@@ -149,13 +149,18 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 			v3.Auth.Scope.Project.Id = c.TenantId
 		} else if c.Tenant != "" {
 			v3.Auth.Scope.Project.Name = c.Tenant
-			var defaultDomain v3Domain
-			if c.Domain != "" {
-				defaultDomain = v3Domain{Name: "Default"}
-			} else if c.DomainId != "" {
-				defaultDomain = v3Domain{Id: "Default"}
+			switch {
+			case c.TenantDomain != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: c.TenantDomain }
+			case c.TenantDomainId != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Id: c.TenantDomainId }
+			case c.Domain != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: c.Domain }
+			case c.DomainId != "":
+				v3.Auth.Scope.Project.Domain = &v3Domain{Id: c.DomainId }
+			default:
+				v3.Auth.Scope.Project.Domain = &v3Domain{Name: "Default" }
 			}
-			v3.Auth.Scope.Project.Domain = &defaultDomain
 		}
 	}
 

--- a/swift.go
+++ b/swift.go
@@ -97,6 +97,8 @@ type Connection struct {
 	Internal       bool              // Set this to true to use the the internal / service network
 	Tenant         string            // Name of the tenant (v2,v3 auth only)
 	TenantId       string            // Id of the tenant (v2,v3 auth only)
+	TenantDomain   string            // Name of the tenant's domain (v3 auth only), only needed if it differs from the user domain
+	TenantDomainId string            // Id of the tenant's domain (v3 auth only), only needed if it differs the from user domain
 	TrustId        string            // Id of the trust (v3 auth only)
 	Transport      http.RoundTripper `json:"-" xml:"-"` // Optional specialised http.Transport (eg. for Google Appengine)
 	// These are filled in after Authenticate is called as are the defaults for above


### PR DESCRIPTION
This commit also removes the hardcoded assumption that a tenant given by its name resides in the domain "Default". The implementation now chooses the user's domain by default, if no tenant domain is given.

I didn't add any tests because, if I read `swifttest/server.go` correctly, there is no infrastructure for testing v3 authentication anyway. Tests pass, though.