### PR TITLE
Allow using adminURL as storage endpoint URL

### DIFF
--- a/swift_test.go
+++ b/swift_test.go
@@ -66,6 +66,7 @@ func makeConnection() (*swift.Connection, error) {
 	ApiKey := os.Getenv("SWIFT_API_KEY")
 	AuthUrl := os.Getenv("SWIFT_AUTH_URL")
 	Region := os.Getenv("SWIFT_REGION_NAME")
+	EndpointType := os.Getenv("SWIFT_ENDPOINT_TYPE")
 
 	Insecure := os.Getenv("SWIFT_AUTH_INSECURE")
 	ConnectionChannelTimeout := os.Getenv("SWIFT_CONNECTION_CHANNEL_TIMEOUT")
@@ -101,6 +102,7 @@ func makeConnection() (*swift.Connection, error) {
 		Transport:      transport,
 		ConnectTimeout: 60 * time.Second,
 		Timeout:        60 * time.Second,
+		EndpointType:   swift.EndpointType(EndpointType),
 	}
 
 	var timeout int64


### PR DESCRIPTION
According to http://developer.openstack.org/api-ref-identity-v2.html#authenticate-v2.0 the `endpoints` response parameter is defined as:

> One or more endpoints objects. Each object shows the adminURL, region, internalURL, id, and publicURL for the endpoint.

Reading the `adminURL` field and the ability to use it as an endpoint, was missing from this library.

This PR changes the signature of `Authenticator.StorageUrl` to receive an `EndpointType` instead of a boolean. Also, I've added an `EndpointType` field to the `Connection` struct to allow users to specify a custom endpoint type.

I tried to keep everything compatible so the `Internal` boolean field remains in the `Connection` struct, if the `EndpointType` is not set and the `Internal` flag is set, the chosen endpoint type will be the internal url otherwise the public url is used.