### PR TITLE
Automatically set Content-Length in ObjectPutBytes/String

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1274,7 +1274,8 @@ func (c *Connection) ObjectPut(container string, objectName string, contents io.
 // This is a simplified interface which checks the MD5.
 func (c *Connection) ObjectPutBytes(container string, objectName string, contents []byte, contentType string) (err error) {
 	buf := bytes.NewBuffer(contents)
-	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, nil)
+	h := Headers{"Content-Length": strconv.Itoa(len(contents))}
+	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, h)
 	return
 }
 
@@ -1283,7 +1284,8 @@ func (c *Connection) ObjectPutBytes(container string, objectName string, content
 // This is a simplified interface which checks the MD5
 func (c *Connection) ObjectPutString(container string, objectName string, contents string, contentType string) (err error) {
 	buf := strings.NewReader(contents)
-	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, nil)
+	h := Headers{"Content-Length": strconv.Itoa(len(contents))}
+	_, err = c.ObjectPut(container, objectName, buf, true, "", contentType, h)
 	return
 }
 

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -404,3 +404,25 @@ func TestInternalContainerNames(t *testing.T) {
 	testContainerNames(t, "one\n", []string{"one"})
 	testContainerNames(t, "one\ntwo\nthree\n", []string{"one", "two", "three"})
 }
+
+func TestInternalObjectPutBytes(t *testing.T) {
+	server.AddCheck(t).In(Headers{
+		"User-Agent":     DefaultUserAgent,
+		"X-Auth-Token":   AUTH_TOKEN,
+		"Content-Length": "5",
+		"Content-Type":   "text/plain",
+	}).Rx("12345")
+	defer server.Finished()
+	c.ObjectPutBytes("container", "object", []byte{'1', '2', '3', '4', '5'}, "text/plain")
+}
+
+func TestInternalObjectPutString(t *testing.T) {
+	server.AddCheck(t).In(Headers{
+		"User-Agent":     DefaultUserAgent,
+		"X-Auth-Token":   AUTH_TOKEN,
+		"Content-Length": "5",
+		"Content-Type":   "text/plain",
+	}).Rx("12345")
+	defer server.Finished()
+	c.ObjectPutString("container", "object", "12345", "text/plain")
+}


### PR DESCRIPTION
Hi

This is a bit opinionated. I'm running the docker registry and noticed that the swift storage backend sends even very small bodies ( e.g. 71 bytes ) in chunks using ObjectPutBytes. This is totally valid. However, I think it would be simpler if ObjectPutBytes/String would insert the Content-Length header automatically as it's trivial to calculate.

Cheers
Hannes
