### PR TITLE
Doing a reauth doesn't eat the first bytes in the body

### DIFF
--- a/compatibility_1_6.go
+++ b/compatibility_1_6.go
@@ -1,0 +1,14 @@
+// +build go1.6
+
+package swift
+
+import (
+	"net/http"
+	"time"
+)
+
+const IS_AT_LEAST_GO_16 = true
+
+func SetExpectContinueTimeout(tr *http.Transport, t time.Duration) {
+	tr.ExpectContinueTimeout = t
+}

--- a/compatibility_1_6.go
+++ b/compatibility_1_6.go
@@ -12,3 +12,10 @@ const IS_AT_LEAST_GO_16 = true
 func SetExpectContinueTimeout(tr *http.Transport, t time.Duration) {
 	tr.ExpectContinueTimeout = t
 }
+
+func AddExpectAndTransferEncoding(req *http.Request, hasContentLength bool) {
+	req.Header.Add("Expect", "100-continue")
+	if !hasContentLength {
+		req.TransferEncoding = []string{"chunked"}
+	}
+}

--- a/compatibility_not_1_6.go
+++ b/compatibility_not_1_6.go
@@ -1,0 +1,12 @@
+// +build !go1.6
+
+package swift
+
+import (
+	"net/http"
+	"time"
+)
+
+const IS_AT_LEAST_GO_16 = false
+
+func SetExpectContinueTimeout(tr *http.Transport, t time.Duration) {}

--- a/compatibility_not_1_6.go
+++ b/compatibility_not_1_6.go
@@ -9,4 +9,5 @@ import (
 
 const IS_AT_LEAST_GO_16 = false
 
-func SetExpectContinueTimeout(tr *http.Transport, t time.Duration) {}
+func SetExpectContinueTimeout(tr *http.Transport, t time.Duration)          {}
+func AddExpectAndTransferEncoding(req *http.Request, hasContentLength bool) {}

--- a/swift.go
+++ b/swift.go
@@ -510,11 +510,9 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 		}
 		req.Header.Add("User-Agent", c.UserAgent)
 		req.Header.Add("X-Auth-Token", authToken)
-		req.Header.Add("Expect", "100-continue")
 
-		if _, hasCL := p.Headers["Content-Length"]; !hasCL {
-			req.TransferEncoding = []string{"chunked"}
-		}
+		_, hasCL := p.Headers["Content-Length"]
+		AddExpectAndTransferEncoding(req, hasCL)
 
 		resp, err = c.doTimeoutRequest(timer, req)
 		if err != nil {

--- a/swift.go
+++ b/swift.go
@@ -254,13 +254,14 @@ func (c *Connection) setDefaults() {
 		c.Timeout = 60 * time.Second
 	}
 	if c.Transport == nil {
-		c.Transport = &http.Transport{
+		t := &http.Transport{
 			//		TLSClientConfig:    &tls.Config{RootCAs: pool},
 			//		DisableCompression: true,
-			Proxy:                 http.ProxyFromEnvironment,
-			MaxIdleConnsPerHost:   2048,
-			ExpectContinueTimeout: 5 * time.Second,
+			Proxy:               http.ProxyFromEnvironment,
+			MaxIdleConnsPerHost: 2048,
 		}
+		SetExpectContinueTimeout(t, 5*time.Second)
+		c.Transport = t
 	}
 	if c.client == nil {
 		c.client = &http.Client{

--- a/swift_test.go
+++ b/swift_test.go
@@ -87,13 +87,13 @@ func makeConnection() (*swift.Connection, error) {
 	}
 
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		MaxIdleConnsPerHost:   2048,
-		ExpectContinueTimeout: 5 * time.Second,
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConnsPerHost: 2048,
 	}
 	if Insecure == "1" {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
+	swift.SetExpectContinueTimeout(transport, 5*time.Second)
 
 	c := swift.Connection{
 		UserName:       UserName,
@@ -646,8 +646,8 @@ func TestObjectPut(t *testing.T) {
 }
 
 func TestObjectPutWithReauth(t *testing.T) {
-	if err := c.ContainerCreate(CONTAINER, m1.ContainerHeaders()); err != nil {
-		t.Fatal(err)
+	if !swift.IS_AT_LEAST_GO_16 {
+		return
 	}
 
 	// Simulate that our auth token expired
@@ -675,8 +675,8 @@ func TestObjectPutWithReauth(t *testing.T) {
 }
 
 func TestObjectPutStringWithReauth(t *testing.T) {
-	if err := c.ContainerCreate(CONTAINER, m1.ContainerHeaders()); err != nil {
-		t.Fatal(err)
+	if !swift.IS_AT_LEAST_GO_16 {
+		return
 	}
 
 	// Simulate that our auth token expired


### PR DESCRIPTION
This should hopefully fix #71. It uses Expect: 100-continue. The trick to get it working properly was to set TransferEncoding: []string{"chunked"} on the request object.
