### PR TITLE
limit the read size of the watchdogReader

### DIFF
--- a/watchdog_reader_test.go
+++ b/watchdog_reader_test.go
@@ -3,6 +3,8 @@
 package swift
 
 import (
+	"bytes"
+	"io"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -12,7 +14,17 @@ import (
 
 func testWatchdogReaderTimeout(t *testing.T, initialTimeout, watchdogTimeout time.Duration, expectedTimeout bool) {
 	test := newTestReader(3, 10*time.Millisecond)
-	timer := time.NewTimer(initialTimeout)
+	timer, firedChan := setupTimer(initialTimeout)
+	wr := newWatchdogReader(test, watchdogTimeout, timer)
+	b, err := ioutil.ReadAll(wr)
+	if err != nil || string(b) != "AAA" {
+		t.Fatalf("Bad read %s %s", err, b)
+	}
+	checkTimer(t, firedChan, expectedTimeout)
+}
+
+func setupTimer(initialTimeout time.Duration) (timer *time.Timer, fired <-chan bool) {
+	timer = time.NewTimer(initialTimeout)
 	firedChan := make(chan bool)
 	started := make(chan bool)
 	go func() {
@@ -23,11 +35,10 @@ func testWatchdogReaderTimeout(t *testing.T, initialTimeout, watchdogTimeout tim
 		}
 	}()
 	<-started
-	wr := newWatchdogReader(test, watchdogTimeout, timer)
-	b, err := ioutil.ReadAll(wr)
-	if err != nil || string(b) != "AAA" {
-		t.Fatalf("Bad read %s %s", err, b)
-	}
+	return timer, firedChan
+}
+
+func checkTimer(t *testing.T, firedChan <-chan bool, expectedTimeout bool) {
 	fired := false
 	select {
 	case fired = <-firedChan:
@@ -58,4 +69,45 @@ func TestWatchdogReaderNoTimeoutShortInitial(t *testing.T) {
 
 func TestWatchdogReaderTimeoutLongInitial(t *testing.T) {
 	testWatchdogReaderTimeout(t, 100*time.Millisecond, 5*time.Millisecond, true)
+}
+
+//slowReader simulates reading from a slow network connection by introducing a delay
+//in each Read() proportional to the amount of bytes read.
+type slowReader struct {
+	reader       io.Reader
+	delayPerByte time.Duration
+}
+
+func (r *slowReader) Read(p []byte) (n int, err error) {
+	n, err = r.reader.Read(p)
+	if n > 0 {
+		time.Sleep(time.Duration(n) * r.delayPerByte)
+	}
+	return
+}
+
+//This test verifies that the watchdogReader's timeout is not triggered by data
+//that comes in very slowly. (It should only be triggered if no data arrives at
+//all.)
+func TestWatchdogReaderOnSlowNetwork(t *testing.T) {
+	byteString := make([]byte, 4<<20) //4 MiB
+	reader := &slowReader{
+		reader: bytes.NewReader(byteString),
+		//reading everything at once would take 100 ms, which is longer than the
+		//watchdog timeout below
+		delayPerByte: 100 * time.Millisecond / time.Duration(len(byteString)),
+	}
+
+	timer, firedChan := setupTimer(10 * time.Millisecond)
+	wr := newWatchdogReader(reader, 50*time.Millisecond, timer)
+
+	//use io.ReadFull instead of ioutil.ReadAll here because ReadAll already does
+	//some chunking that would keep this testcase from failing
+	b := make([]byte, len(byteString))
+	n, err := io.ReadFull(wr, b)
+	if err != nil || n != len(b) || !bytes.Equal(b, byteString) {
+		t.Fatal("Bad read %s %d", err, n)
+	}
+
+	checkTimer(t, firedChan, false)
 }

--- a/watchdog_reader_test.go
+++ b/watchdog_reader_test.go
@@ -90,16 +90,16 @@ func (r *slowReader) Read(p []byte) (n int, err error) {
 //that comes in very slowly. (It should only be triggered if no data arrives at
 //all.)
 func TestWatchdogReaderOnSlowNetwork(t *testing.T) {
-	byteString := make([]byte, 4*watchdogChunkSize)
+	byteString := make([]byte, 8*watchdogChunkSize)
 	reader := &slowReader{
 		reader: bytes.NewReader(byteString),
 		//reading everything at once would take 100 ms, which is longer than the
 		//watchdog timeout below
-		delayPerByte: 100 * time.Millisecond / time.Duration(len(byteString)),
+		delayPerByte: 200 * time.Millisecond / time.Duration(len(byteString)),
 	}
 
 	timer, firedChan := setupTimer(10 * time.Millisecond)
-	wr := newWatchdogReader(reader, 50*time.Millisecond, timer)
+	wr := newWatchdogReader(reader, 190*time.Millisecond, timer)
 
 	//use io.ReadFull instead of ioutil.ReadAll here because ReadAll already does
 	//some chunking that would keep this testcase from failing

--- a/watchdog_reader_test.go
+++ b/watchdog_reader_test.go
@@ -90,7 +90,7 @@ func (r *slowReader) Read(p []byte) (n int, err error) {
 //that comes in very slowly. (It should only be triggered if no data arrives at
 //all.)
 func TestWatchdogReaderOnSlowNetwork(t *testing.T) {
-	byteString := make([]byte, 4<<20) //4 MiB
+	byteString := make([]byte, 4*watchdogChunkSize)
 	reader := &slowReader{
 		reader: bytes.NewReader(byteString),
 		//reading everything at once would take 100 ms, which is longer than the


### PR DESCRIPTION
As is already noted in a FIXME in the code, the watchdog reader should not read too much data at once, because when data trickles in only very slowly (because the network connection is slow), this might cause the watchdog timer to fire, thus triggering a connection reset although data is still coming in (only slowly).

To give some numbers as to why this is relevant, we triggered this issue in a productive setup of my [swift-http-import](https://github.com/sapcc/swift-http-import) while attempting to mirror an Ubuntu repo into Swift, in particular when downloading a 1.3 GiB package file from the source and uploading it into Swift without using an extra buffer in between (i.e. the `response.Body` from `http.Get` is passed directly into `ObjectPut`).