### PR TITLE
fix slicing in watchdog reader

### DIFF
--- a/watchdog_reader.go
+++ b/watchdog_reader.go
@@ -40,7 +40,7 @@ func (t *watchdogReader) Read(p []byte) (int, error) {
 		}
 
 		resetTimer(t.timer, t.timeout)
-		n, err := t.reader.Read(p[start:length])
+		n, err := t.reader.Read(p[start : start+length])
 		start += n
 		if n == 0 || err != nil {
 			return start, err

--- a/watchdog_reader.go
+++ b/watchdog_reader.go
@@ -9,23 +9,25 @@ var watchdogChunkSize = 1 << 20 // 1 MiB
 
 // An io.Reader which resets a watchdog timer whenever data is read
 type watchdogReader struct {
-	timeout time.Duration
-	reader  io.Reader
-	timer   *time.Timer
+	timeout   time.Duration
+	reader    io.Reader
+	timer     *time.Timer
+	chunkSize int
 }
 
 // Returns a new reader which will kick the watchdog timer whenever data is read
 func newWatchdogReader(reader io.Reader, timeout time.Duration, timer *time.Timer) *watchdogReader {
 	return &watchdogReader{
-		timeout: timeout,
-		reader:  reader,
-		timer:   timer,
+		timeout:   timeout,
+		reader:    reader,
+		timer:     timer,
+		chunkSize: watchdogChunkSize,
 	}
 }
 
 // Read reads up to len(p) bytes into p
 func (t *watchdogReader) Read(p []byte) (int, error) {
-	//read from underlying reader in chunks not larger than watchdogChunkSize
+	//read from underlying reader in chunks not larger than t.chunkSize
 	//while resetting the watchdog timer before every read; the small chunk
 	//size ensures that the timer does not fire when reading a large amount of
 	//data from a slow connection
@@ -33,8 +35,8 @@ func (t *watchdogReader) Read(p []byte) (int, error) {
 	end := len(p)
 	for start < end {
 		length := end - start
-		if length > watchdogChunkSize {
-			length = watchdogChunkSize
+		if length > t.chunkSize {
+			length = t.chunkSize
 		}
 
 		resetTimer(t.timer, t.timeout)


### PR DESCRIPTION
I just updated [my application](https://github.com/sapcc/swift-http-import) to include the fix from #85, and it promptly crashed with a `slice bounds out of range` exception.

A quick round of debugging, followed by a careful re-reading of the Go language specification tells me that slices are specified as `[start:end]` rather than `[start:length]`. How the unit tests, myself and two reviewers could have missed this before eludes me.