### PR TITLE
Always read HTTP response body in case of an error

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -202,6 +203,12 @@ func checkClose(c io.Closer, err *error) {
 func (c *Connection) parseHeaders(resp *http.Response, errorMap errorMap) error {
 	if errorMap != nil {
 		if err, ok := errorMap[resp.StatusCode]; ok {
+			if resp.Body != nil {
+				// drain the body before returning an error, so the connection can
+				// be reused
+				_, _ = io.Copy(ioutil.Discard, resp.Body)
+			}
+
 			return err
 		}
 	}

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -214,15 +214,19 @@ func TestInternalError(t *testing.T) {
 
 }
 
-func testCheckClose(c io.Closer, e error) (err error) {
+func testCheckClose(rd io.ReadCloser, e error) (err error) {
 	err = e
-	defer checkClose(c, &err)
+	defer checkClose(rd, &err)
 	return
 }
 
 // Make a closer which returns the error of our choice
 type myCloser struct {
 	err error
+}
+
+func (c *myCloser) Read([]byte) (int, error) {
+	return 0, io.EOF
 }
 
 func (c *myCloser) Close() error {


### PR DESCRIPTION
This allows reusing the same connection for future requests. A connection is aborted when the body is closed before reading it completely.