### PR TITLE
add StatusCode() to ObjectOpenFile to detect "304 Not Modified" responses

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1530,6 +1530,15 @@ type ObjectOpenFile struct {
 	overSeeked bool           // set if we have seeked to the end or beyond
 }
 
+//StatusCode returns the HTTP status code that Swift returned when this file
+//was opened for reading. If at least one of the If-None-Match or
+//If-Last-Modified headers were specified during opening, this code may be 304
+//to indicate that the file was not modified, in which case Read() will not
+//return any bytes.
+func (file *ObjectOpenFile) StatusCode() int {
+	return file.resp.StatusCode
+}
+
 // Read bytes from the object - see io.Reader
 func (file *ObjectOpenFile) Read(p []byte) (n int, err error) {
 	if file.overSeeked {


### PR DESCRIPTION
My use-case is mirroring files from a Swift container to some other storage. I'm recording the `Etag` and `Last-Modified` headers of the files mirrored, and on subsequent mirroring runs I give the corresponding `If-None-Match` and `If-Modified-Since` headers to `Connection.ObjectOpen()` so that Swift can answer with `304 Not Modified` for files that don't need modifying.

However, the `type ObjectOpenFile` returned by `Connection.ObjectOpen()` does not expose this information. This PR adds a `StatusCode()` method to fix this.

For additional context, [this is where I intend to use this.](https://github.com/sapcc/swift-http-import/blob/a2a14b01f47f9b93109014eead638095aa41802e/file.go#L176)