### PR TITLE
catch "304 Not Modified" response to ObjectOpen() correctly

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -284,6 +284,7 @@ type errorMap map[int]error
 
 var (
 	// Specific Errors you might want to check for equality
+	NotModified         = newError(304, "Not Modified")
 	BadRequest          = newError(400, "Bad Request")
 	AuthorizationFailed = newError(401, "Authorization Failed")
 	ContainerNotFound   = newError(404, "Container Not Found")
@@ -311,6 +312,7 @@ var (
 
 	// Mappings for object errors
 	objectErrorMap = errorMap{
+		304: NotModified,
 		400: BadRequest,
 		403: Forbidden,
 		404: ObjectNotFound,


### PR DESCRIPTION
This is a followup to #94, in which I didn't consider that a 304 response from Swift during `ObjectOpen()` will not produce a non-nil `*ObjectOpenFile`. It will simply exit with an error.

This patch allows response status 304 to be detected via`err == swift.NotModified.`

To ensure that I didn't miss anything else, I've vendored this into [swift-http-import](https://github.com/sapcc/swift-http-import) in [this commit](https://github.com/sapcc/swift-http-import/commit/f0d6c184d2a3cf2aa433d200036fa26d14d081e4) and checked that its test suite passes.

@cezarsa Considering this, how do you feel about reverting #94? I don't see any other cases where the `ObjectOpenFile.StatusCode()` method would be useful.