### PR TITLE
Change struct alignment to work on both 32 and 64 bit OS. Fix #96

### DIFF
--- a/swifttest/server.go
+++ b/swifttest/server.go
@@ -44,9 +44,12 @@ const (
 type HandlerOverrideFunc func(w http.ResponseWriter, r *http.Request, recorder *httptest.ResponseRecorder)
 
 type SwiftServer struct {
+	// `sync/atomic` expects the first word in an allocated struct to be 64-bit
+	// aligned on both ARM and x86-32.
+	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more details.
+	reqId    int64
 	sync.RWMutex
 	t        *testing.T
-	reqId    int64
 	mu       sync.Mutex
 	Listener net.Listener
 	AuthURL  string
@@ -121,12 +124,15 @@ type object struct {
 }
 
 type container struct {
+	// `sync/atomic` expects the first word in an allocated struct to be 64-bit
+	// aligned on both ARM and x86-32.
+	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more details.
+	bytes   int64
 	sync.RWMutex
 	metadata
 	name    string
 	ctime   time.Time
 	objects map[string]*object
-	bytes   int64
 }
 
 type segment struct {

--- a/swifttest/server.go
+++ b/swifttest/server.go
@@ -47,7 +47,7 @@ type SwiftServer struct {
 	// `sync/atomic` expects the first word in an allocated struct to be 64-bit
 	// aligned on both ARM and x86-32.
 	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more details.
-	reqId    int64
+	reqId int64
 	sync.RWMutex
 	t        *testing.T
 	mu       sync.Mutex
@@ -127,7 +127,7 @@ type container struct {
 	// `sync/atomic` expects the first word in an allocated struct to be 64-bit
 	// aligned on both ARM and x86-32.
 	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more details.
-	bytes   int64
+	bytes int64
 	sync.RWMutex
 	metadata
 	name    string


### PR DESCRIPTION
`sync/atomic` expects the first word in an allocated struct to be 64-bit aligned on both ARM and x86-32.  See https://golang.org/pkg/sync/atomic/#pkg-note-BUG for more details.

Fixes #96 