### PR TITLE
Support UserId for auth v3

### DIFF
--- a/auth_v3.go
+++ b/auth_v3.go
@@ -117,7 +117,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 
 	v3 := v3AuthRequest{}
 
-	if c.UserName == "" {
+	if c.UserName == "" && c.UserId == "" {
 		v3.Auth.Identity.Methods = []string{v3AuthMethodToken}
 		v3.Auth.Identity.Token = &v3AuthToken{Id: c.ApiKey}
 	} else {
@@ -125,6 +125,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 		v3.Auth.Identity.Password = &v3AuthPassword{
 			User: v3User{
 				Name:     c.UserName,
+				Id:       c.UserId,
 				Password: c.ApiKey,
 			},
 		}

--- a/swift.go
+++ b/swift.go
@@ -99,6 +99,7 @@ type Connection struct {
 	Domain         string            // User's domain name
 	DomainId       string            // User's domain Id
 	UserName       string            // UserName for api
+	UserId         string            // User Id
 	ApiKey         string            // Key for api access
 	AuthUrl        string            // Auth URL
 	Retries        int               // Retries on error (default is 3)
@@ -191,6 +192,7 @@ func setFromEnv(param interface{}, name string) (err error) {
 // For v3 authentication
 //     OS_AUTH_URL - Auth URL
 //     OS_USERNAME - UserName for api
+//     OS_USER_ID - User Id
 //     OS_PASSWORD - Key for api access
 //     OS_USER_DOMAIN_NAME - User's domain name
 //     OS_USER_DOMAIN_ID - User's domain Id
@@ -223,6 +225,7 @@ func (c *Connection) ApplyEnvironment() (err error) {
 		{&c.Domain, "OS_USER_DOMAIN_NAME"},
 		{&c.DomainId, "OS_USER_DOMAIN_ID"},
 		{&c.UserName, "OS_USERNAME"},
+		{&c.UserId, "OS_USER_ID"},
 		{&c.ApiKey, "OS_PASSWORD"},
 		{&c.AuthUrl, "OS_AUTH_URL"},
 		{&c.Retries, "GOSWIFT_RETRIES"},

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -576,6 +576,7 @@ func TestApplyEnvironmentAll(t *testing.T) {
 			{1, &c.Domain, "OS_USER_DOMAIN_NAME", "os_user_domain_name", "os_user_domain_name", ""},
 			{1, &c.DomainId, "OS_USER_DOMAIN_ID", "os_user_domain_id", "os_user_domain_id", ""},
 			{1, &c.UserName, "OS_USERNAME", "os_username", "os_username", ""},
+			{1, &c.UserId, "OS_USER_ID", "os_user_id", "os_user_id", ""},
 			{1, &c.ApiKey, "OS_PASSWORD", "os_password", "os_password", ""},
 			{1, &c.AuthUrl, "OS_AUTH_URL", "os_auth_url", "os_auth_url", ""},
 			{1, &c.Retries, "GOSWIFT_RETRIES", "4", 4, ""},


### PR DESCRIPTION
Authentication in IBM Bluemix requires UserId instead of UserName