### PR TITLE
Error for RateLimit

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -297,6 +297,7 @@ var (
 	TimeoutError        = newError(408, "Timeout when reading or writing data")
 	Forbidden           = newError(403, "Operation forbidden")
 	TooLargeObject      = newError(413, "Too Large Object")
+	RateLimit           = newError(498, "Rate Limit")
 
 	// Mappings for authentication errors
 	authErrorMap = errorMap{
@@ -311,6 +312,7 @@ var (
 		403: Forbidden,
 		404: ContainerNotFound,
 		409: ContainerNotEmpty,
+		498: RateLimit,
 	}
 
 	// Mappings for object errors
@@ -321,6 +323,7 @@ var (
 		404: ObjectNotFound,
 		413: TooLargeObject,
 		422: ObjectCorrupted,
+		498: RateLimit,
 	}
 )
 

--- a/watchdog_reader_test.go
+++ b/watchdog_reader_test.go
@@ -106,7 +106,7 @@ func TestWatchdogReaderOnSlowNetwork(t *testing.T) {
 	b := make([]byte, len(byteString))
 	n, err := io.ReadFull(wr, b)
 	if err != nil || n != len(b) || !bytes.Equal(b, byteString) {
-		t.Fatal("Bad read %s %d", err, n)
+		t.Fatalf("Bad read %s %d", err, n)
 	}
 
 	checkTimer(t, firedChan, false)
@@ -129,9 +129,9 @@ func TestWatchdogReaderValidity(t *testing.T) {
 	b := make([]byte, len(byteString))
 	n, err := io.ReadFull(wr, b)
 	if err != nil || n != len(b) {
-		t.Fatal("Read error: %s", err)
+		t.Fatalf("Read error: %s", err)
 	}
 	if !bytes.Equal(b, byteString) {
-		t.Fatal("Bad read: %#v != %#v", string(b), string(byteString))
+		t.Fatalf("Bad read: %#v != %#v", string(b), string(byteString))
 	}
 }


### PR DESCRIPTION
If the backend Swift responds with a RateLimit - HTTP Code `498` - the caller might act accordingly and slow down. To make that easier for the users of that library, introducing a concrete Error for that situation.

https://docs.openstack.org/swift/latest/ratelimit.html