### PR TITLE
Fix bulk delete

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1843,7 +1843,8 @@ type BulkDeleteResult struct {
 func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, err error) {
 	var buffer bytes.Buffer
 	for _, s := range objects {
-		buffer.WriteString(url.QueryEscape(s) + "\n")
+		u := url.URL{Path: s}
+		buffer.WriteString(u.String() + "\n")
 	}
 	resp, headers, err := c.storage(RequestOpts{
 		Operation:  "DELETE",

--- a/swift.go
+++ b/swift.go
@@ -1850,8 +1850,9 @@ func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, er
 		Operation:  "DELETE",
 		Parameters: url.Values{"bulk-delete": []string{"1"}},
 		Headers: Headers{
-			"Accept":       "application/json",
-			"Content-Type": "text/plain",
+			"Accept":         "application/json",
+			"Content-Type":   "text/plain",
+			"Content-Length": strconv.Itoa(buffer.Len()),
 		},
 		ErrorMap: ContainerErrorMap,
 		Body:     &buffer,


### PR DESCRIPTION
File paths was overencoded (slashes replaced by %2F) and as result bulk delete fails with some Swift implementations