### PR TITLE
Do not send a request when BulkDelete slice is empty

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1895,6 +1895,10 @@ func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, er
 // * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-bulk-delete.html
 // * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Bulk_Delete-d1e2338.html
 func (c *Connection) BulkDelete(container string, objectNames []string) (result BulkDeleteResult, err error) {
+	if len(objectNames) == 0 {
+		result.Errors = make(map[string]error)
+		return
+	}
 	fullPaths := make([]string, len(objectNames))
 	for i, name := range objectNames {
 		fullPaths[i] = fmt.Sprintf("/%s/%s", container, name)


### PR DESCRIPTION
We have made this change some months ago and used it in production since then without issues. I think it was to avoid some weird messages in log files, but I'm not sure.

cc: @jinroh