### PR TITLE
Add slo_etag support when Swift is running 2.19.0+.

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1013,7 +1013,8 @@ type Object struct {
 	Bytes              int64      `json:"bytes"`         // size in bytes
 	ServerLastModified string     `json:"last_modified"` // Last modified time, eg '2011-06-30T08:20:47.736680' as a string supplied by the server
 	LastModified       time.Time  // Last modified time converted to a time.Time
-	Hash               string     `json:"hash"` // MD5 hash, eg "d41d8cd98f00b204e9800998ecf8427e"
+	Hash               string     `json:"hash"`     // MD5 hash, eg "d41d8cd98f00b204e9800998ecf8427e"
+	SLOHash            string     `json:"slo_etag"` // MD5 hash of all segments' MD5 hash, eg "d41d8cd98f00b204e9800998ecf8427e"
 	PseudoDirectory    bool       // Set when using delimiter to show that this directory object does not really exist
 	SubDir             string     `json:"subdir"` // returned only when using delimiter to mark "pseudo directories"
 	ObjectType         ObjectType // type of this object
@@ -1064,6 +1065,9 @@ func (c *Connection) Objects(container string, opts *ObjectsOpts) ([]Object, err
 			if err != nil {
 				return nil, err
 			}
+		}
+		if object.SLOHash != "" {
+			object.ObjectType = StaticLargeObjectType
 		}
 	}
 	return objects, err


### PR DESCRIPTION
https://github.com/openstack/swift/blob/f0472f1f7975957fc31cb8c123aa82ee47848645/CHANGELOG#L40-L44