### PR TITLE
Support status 429 for OVH Cloud Archive

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -307,6 +307,7 @@ var (
 	Forbidden           = newError(403, "Operation forbidden")
 	TooLargeObject      = newError(413, "Too Large Object")
 	RateLimit           = newError(498, "Rate Limit")
+	TooManyRequests     = newError(429, "TooManyRequests")
 
 	// Mappings for authentication errors
 	authErrorMap = errorMap{
@@ -332,6 +333,7 @@ var (
 		404: ObjectNotFound,
 		413: TooLargeObject,
 		422: ObjectCorrupted,
+		429: TooManyRequests,
 		498: RateLimit,
 	}
 )
@@ -754,10 +756,10 @@ func (c *Connection) Call(targetUrl string, p RequestOpts) (resp *http.Response,
 		}
 	}
 
-	if err = c.parseHeaders(resp, p.ErrorMap); err != nil {
-		return nil, nil, err
-	}
 	headers = readHeaders(resp)
+	if err = c.parseHeaders(resp, p.ErrorMap); err != nil {
+		return nil, headers, err
+	}
 	if p.NoResponse {
 		var err error
 		drainAndClose(resp.Body, &err)


### PR DESCRIPTION
Before being able to retrieve an object from OVH Cloud Archive, an object
must be unfreezed. First call and subsequent calls until the object is
available, OVH will return a 429 status and Retry-After header set to a
time in seconds after which the object should be available.

This change makes status 429 a testable error, and returns headers, so the
caller can extract the Retry-After header.

Fixes #140 