### PR TITLE
headers are not processed when creating dynamic large object. fixes #147

### DIFF
--- a/dlo.go
+++ b/dlo.go
@@ -2,6 +2,7 @@ package swift
 
 import (
 	"os"
+	"strings"
 )
 
 // DynamicLargeObjectCreateFile represents an open static large object
@@ -45,7 +46,7 @@ func (c *Connection) DynamicLargeObjectMove(srcContainer string, srcObjectName s
 	}
 
 	segmentContainer, segmentPath := parseFullPath(headers["X-Object-Manifest"])
-	if err := c.createDLOManifest(dstContainer, dstObjectName, segmentContainer+"/"+segmentPath, info.ContentType); err != nil {
+	if err := c.createDLOManifest(dstContainer, dstObjectName, segmentContainer+"/"+segmentPath, info.ContentType, sanitizeLargeObjectMoveHeaders(headers)); err != nil {
 		return err
 	}
 
@@ -56,9 +57,18 @@ func (c *Connection) DynamicLargeObjectMove(srcContainer string, srcObjectName s
 	return nil
 }
 
+func sanitizeLargeObjectMoveHeaders(headers Headers) Headers {
+	sanitizedHeaders := make(map[string]string, len(headers))
+	for k, v := range headers {
+		if strings.HasPrefix(k, "X-") { //Some of the fields does not effect the request e,g, X-Timestamp, X-Trans-Id, X-Openstack-Request-Id. Open stack will generate new ones anyway.
+			sanitizedHeaders[k] = v
+		}
+	}
+	return sanitizedHeaders
+}
+
 // createDLOManifest creates a dynamic large object manifest
-func (c *Connection) createDLOManifest(container string, objectName string, prefix string, contentType string) error {
-	headers := make(Headers)
+func (c *Connection) createDLOManifest(container string, objectName string, prefix string, contentType string, headers Headers) error {
 	headers["X-Object-Manifest"] = prefix
 	manifest, err := c.ObjectCreate(container, objectName, false, "", contentType, headers)
 	if err != nil {
@@ -78,7 +88,7 @@ func (file *DynamicLargeObjectCreateFile) Close() error {
 }
 
 func (file *DynamicLargeObjectCreateFile) Flush() error {
-	err := file.conn.createDLOManifest(file.container, file.objectName, file.segmentContainer+"/"+file.prefix, file.contentType)
+	err := file.conn.createDLOManifest(file.container, file.objectName, file.segmentContainer+"/"+file.prefix, file.contentType, file.headers)
 	if err != nil {
 		return err
 	}

--- a/dlo.go
+++ b/dlo.go
@@ -69,6 +69,9 @@ func sanitizeLargeObjectMoveHeaders(headers Headers) Headers {
 
 // createDLOManifest creates a dynamic large object manifest
 func (c *Connection) createDLOManifest(container string, objectName string, prefix string, contentType string, headers Headers) error {
+	if headers == nil {
+		headers = make(Headers)
+	}
 	headers["X-Object-Manifest"] = prefix
 	manifest, err := c.ObjectCreate(container, objectName, false, "", contentType, headers)
 	if err != nil {

--- a/dlo_test.go
+++ b/dlo_test.go
@@ -12,7 +12,7 @@ var srv *swifttest.SwiftServer
 var con *Connection
 var err error
 var filecontent = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-var segmentContainer = "segment_container"
+var segmentContainer = "segment_container112"
 
 func initTest(t *testing.T) {
 	con, err = initTestConnection(t)
@@ -26,6 +26,7 @@ func teardown() {
 		srv.Close()
 	}
 }
+
 func initTestConnection(t *testing.T) (*Connection, error) {
 	//Uses /swifttest
 	//in-memory implementation to start
@@ -71,14 +72,16 @@ func createContainers(containers []string, t *testing.T) {
 }
 
 func createDynamicObject(container, object string, t *testing.T) {
+	metadata := map[string]string{}
+	metadata["Custom-Field"] = "SomeValue"
 	ops := LargeObjectOpts{
-		Container:        container,                                     // Name of container to place object
-		ObjectName:       object,                                        // Name of object
-		CheckHash:        false,                                         // If set Check the hash
-		ContentType:      "application/octet-stream",                    // Content-Type of the object
-		Headers:          Metadata(map[string]string{}).ObjectHeaders(), // Additional headers to upload the object with
-		SegmentContainer: segmentContainer,                              // Name of the container to place segments
-		SegmentPrefix:    "sg",                                          // Prefix to use for the segments
+		Container:        container,                          // Name of container to place object
+		ObjectName:       object,                             // Name of object
+		CheckHash:        false,                              // If set Check the hash
+		ContentType:      "application/octet-stream",         // Content-Type of the object
+		Headers:          Metadata(metadata).ObjectHeaders(), // Additional headers to upload the object with
+		SegmentContainer: segmentContainer,                   // Name of the container to place segments
+		SegmentPrefix:    "sg",                               // Prefix to use for the segments
 	}
 	bigfile, err := con.DynamicLargeObjectCreate(&ops)
 	if err != nil {
@@ -99,6 +102,10 @@ func checkObject(container, object string, t *testing.T) {
 	if info.Bytes != 10 {
 		t.Errorf("Fail: mismatch content lengh")
 	}
+	if val, ok := header["X-Object-Meta-Custom-Field"]; !ok || val != "SomeValue" {
+		t.Errorf("Fail: lost custom metadata header")
+	}
+
 	content, err := con.ObjectGetBytes(container, object)
 	if err != nil {
 		t.Errorf("Fail at read Large Object : %s", err.Error())
@@ -106,6 +113,7 @@ func checkObject(container, object string, t *testing.T) {
 	if !bytes.Equal(content, filecontent) {
 		t.Errorf("Fail: mismatch content")
 	}
+
 }
 func checkNotExistObject(container, object string, t *testing.T) {
 	_, _, err = con.Object(container, object)
@@ -136,14 +144,16 @@ func deleteDynamicObject(container, object string, t *testing.T) {
 	}
 }
 func createStaticObject(container, object string, t *testing.T) {
+	metadata := map[string]string{}
+	metadata["Custom-Field"] = "SomeValue"
 	ops := LargeObjectOpts{
-		Container:        container,                                     // Name of container to place object
-		ObjectName:       object,                                        // Name of object
-		CheckHash:        false,                                         // If set Check the hash
-		ContentType:      "application/octet-stream",                    // Content-Type of the object
-		Headers:          Metadata(map[string]string{}).ObjectHeaders(), // Additional headers to upload the object with
-		SegmentContainer: segmentContainer,                              // Name of the container to place segments
-		SegmentPrefix:    "sg",                                          // Prefix to use for the segments
+		Container:        container,                          // Name of container to place object
+		ObjectName:       object,                             // Name of object
+		CheckHash:        false,                              // If set Check the hash
+		ContentType:      "application/octet-stream",         // Content-Type of the object
+		Headers:          Metadata(metadata).ObjectHeaders(), // Additional headers to upload the object with
+		SegmentContainer: segmentContainer,                   // Name of the container to place segments
+		SegmentPrefix:    "sg",                               // Prefix to use for the segments
 	}
 	bigfile, err := con.StaticLargeObjectCreate(&ops)
 	if err != nil {


### PR DESCRIPTION
headers are now passed in when creating dynamic large object.
When dynamic large object move, headers are also kept.