### PR TITLE
Fix authLock mutex, added a pointer on it

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -125,7 +125,7 @@ type Connection struct {
 	Expires    time.Time // time the token expires, may be Zero if unknown
 	client     *http.Client
 	Auth       Authenticator `json:"-" xml:"-"` // the current authenticator
-	authLock   sync.Mutex    // lock when R/W StorageUrl, AuthToken, Auth
+	authLock   *sync.Mutex   // lock when R/W StorageUrl, AuthToken, Auth
 	// swiftInfo is filled after QueryInfo is called
 	swiftInfo SwiftInfo
 }
@@ -458,6 +458,9 @@ func (c *Connection) setDefaults() {
 // If you don't call it before calling one of the connection methods
 // then it will be called for you on the first access.
 func (c *Connection) Authenticate() (err error) {
+	if c.authLock == nil {
+		c.authLock = &sync.Mutex{}
+	}
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 	return c.authenticate()
@@ -580,6 +583,9 @@ func (c *Connection) UnAuthenticate() {
 //
 // Doesn't actually check the credentials against the server.
 func (c *Connection) Authenticated() bool {
+	if c.authLock == nil {
+		c.authLock = &sync.Mutex{}
+	}
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 	return c.authenticated()


### PR DESCRIPTION
Hello,

`go vet` is reporting an issue with the Mutex value in struct `Connection`.

```sh
go vet ./...
swift/client.go:34:30: literal copies lock value from c: .../vendor/github.com/ncw/swift.Connection contains sync.Mutex
```

It should be a pointer instead of a value, I have updated the package to fix this issue.

