### PR TITLE
Expose CloseWithError on ObjectCreateFile

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1372,6 +1372,13 @@ func (file *ObjectCreateFile) Write(p []byte) (n int, err error) {
 	return
 }
 
+// CloseWithError closes the object, aborting the upload.
+func (file *ObjectCreateFile) CloseWithError(err error) error {
+	_ = file.pipeWriter.CloseWithError(err)
+	<-file.done
+	return nil
+}
+
 // Close the object and checks the md5sum if it was required.
 //
 // Also returns any other errors from the server (eg container not


### PR DESCRIPTION
Expose `.CloseWithError` on `ObjectCreateFile` to allow uploads to be aborted.

Ideally, we would add this to `DynamicLargeObjectCreate` and `StaticLargeObjectCreate` but because of the support for seeking it looks like it gets complicated very quickly. I am happy to help do that, but I would need guidance on the best way to do it, and I would rather do that in a separate PR.