### PR TITLE
refactor: add custom headers to BulkDelete

### DIFF
--- a/largeobjects.go
+++ b/largeobjects.go
@@ -222,7 +222,7 @@ func (c *Connection) LargeObjectDelete(container string, objectName string) erro
 		for i, obj := range objects {
 			filenames[i] = obj[0] + "/" + obj[1]
 		}
-		_, err = c.doBulkDelete(filenames)
+		_, err = c.doBulkDelete(filenames, nil)
 		// Don't fail on ObjectNotFound because eventual consistency
 		// makes this situation normal.
 		if err != nil && err != Forbidden && err != ObjectNotFound {

--- a/swift.go
+++ b/swift.go
@@ -1967,7 +1967,19 @@ func (c *Connection) doBulkDelete(objects []string, h Headers) (result BulkDelet
 // See also:
 // * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-bulk-delete.html
 // * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Bulk_Delete-d1e2338.html
-func (c *Connection) BulkDelete(container string, objectNames []string, h Headers) (result BulkDeleteResult, err error) {
+func (c *Connection) BulkDelete(container string, objectNames []string) (result BulkDeleteResult, err error) {
+	return c.BulkDeleteHeaders(container, objectNames, nil)
+}
+
+// BulkDeleteHeaders deletes multiple objectNames from container in one operation.
+//
+// Some servers may not accept bulk-delete requests since bulk-delete is
+// an optional feature of swift - these will return the Forbidden error.
+//
+// See also:
+// * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-bulk-delete.html
+// * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Bulk_Delete-d1e2338.html
+func (c *Connection) BulkDeleteHeaders(container string, objectNames []string, h Headers) (result BulkDeleteResult, err error) {
 	if len(objectNames) == 0 {
 		result.Errors = make(map[string]error)
 		return

--- a/swift.go
+++ b/swift.go
@@ -1909,22 +1909,26 @@ type BulkDeleteResult struct {
 	Headers        Headers          // Response HTTP headers.
 }
 
-func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, err error) {
+func (c *Connection) doBulkDelete(objects []string, h Headers) (result BulkDeleteResult, err error) {
 	var buffer bytes.Buffer
 	for _, s := range objects {
 		u := url.URL{Path: s}
 		buffer.WriteString(u.String() + "\n")
 	}
+	extraHeaders := Headers{
+		"Accept":         "application/json",
+		"Content-Type":   "text/plain",
+		"Content-Length": strconv.Itoa(buffer.Len()),
+	}
+	for key, value := range h {
+		extraHeaders[key] = value
+	}
 	resp, headers, err := c.storage(RequestOpts{
 		Operation:  "DELETE",
 		Parameters: url.Values{"bulk-delete": []string{"1"}},
-		Headers: Headers{
-			"Accept":         "application/json",
-			"Content-Type":   "text/plain",
-			"Content-Length": strconv.Itoa(buffer.Len()),
-		},
-		ErrorMap: ContainerErrorMap,
-		Body:     &buffer,
+		Headers:    extraHeaders,
+		ErrorMap:   ContainerErrorMap,
+		Body:       &buffer,
 	})
 	if err != nil {
 		return
@@ -1963,7 +1967,7 @@ func (c *Connection) doBulkDelete(objects []string) (result BulkDeleteResult, er
 // See also:
 // * http://docs.openstack.org/trunk/openstack-object-storage/admin/content/object-storage-bulk-delete.html
 // * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Bulk_Delete-d1e2338.html
-func (c *Connection) BulkDelete(container string, objectNames []string) (result BulkDeleteResult, err error) {
+func (c *Connection) BulkDelete(container string, objectNames []string, h Headers) (result BulkDeleteResult, err error) {
 	if len(objectNames) == 0 {
 		result.Errors = make(map[string]error)
 		return
@@ -1972,7 +1976,7 @@ func (c *Connection) BulkDelete(container string, objectNames []string) (result 
 	for i, name := range objectNames {
 		fullPaths[i] = fmt.Sprintf("/%s/%s", container, name)
 	}
-	return c.doBulkDelete(fullPaths)
+	return c.doBulkDelete(fullPaths, h)
 }
 
 // BulkUploadResult stores results of BulkUpload().

--- a/swift_test.go
+++ b/swift_test.go
@@ -1948,7 +1948,7 @@ func TestObjectDelete(t *testing.T) {
 func TestBulkDelete(t *testing.T) {
 	c, rollback := makeConnectionWithContainer(t)
 	defer rollback()
-	result, err := c.BulkDelete(CONTAINER, []string{OBJECT}, nil)
+	result, err := c.BulkDelete(CONTAINER, []string{OBJECT})
 	if err == swift.Forbidden {
 		t.Log("Server doesn't support BulkDelete - skipping test")
 		return
@@ -1966,7 +1966,7 @@ func TestBulkDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err = c.BulkDelete(CONTAINER, []string{OBJECT2, OBJECT}, nil)
+	result, err = c.BulkDelete(CONTAINER, []string{OBJECT2, OBJECT})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swift_test.go
+++ b/swift_test.go
@@ -1948,7 +1948,7 @@ func TestObjectDelete(t *testing.T) {
 func TestBulkDelete(t *testing.T) {
 	c, rollback := makeConnectionWithContainer(t)
 	defer rollback()
-	result, err := c.BulkDelete(CONTAINER, []string{OBJECT})
+	result, err := c.BulkDelete(CONTAINER, []string{OBJECT}, nil)
 	if err == swift.Forbidden {
 		t.Log("Server doesn't support BulkDelete - skipping test")
 		return
@@ -1966,7 +1966,7 @@ func TestBulkDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err = c.BulkDelete(CONTAINER, []string{OBJECT2, OBJECT})
+	result, err = c.BulkDelete(CONTAINER, []string{OBJECT2, OBJECT}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`BulkUpload` has support for custom headers, but `BulkDelete` does not, this PR enables this functionality.