### PR TITLE
Allow context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,4 @@ Contributors
 - Thiago da Silva <thiagodasilva@users.noreply.github.com>
 - Brandon WELSCH <dev@brandon-welsch.eu>
 - Damien Tournoud <damien@platform.sh>
+- Pedro Kiefer <pedro@kiefer.com.br>

--- a/README.md
+++ b/README.md
@@ -161,3 +161,4 @@ Contributors
 - Brandon WELSCH <dev@brandon-welsch.eu>
 - Damien Tournoud <damien@platform.sh>
 - Pedro Kiefer <pedro@kiefer.com.br>
+- Martin Chodur <m.chodur@seznam.cz>

--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package swift
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -14,7 +15,7 @@ import (
 // This encapsulates the different authentication schemes in use
 type Authenticator interface {
 	// Request creates an http.Request for the auth - return nil if not needed
-	Request(*Connection) (*http.Request, error)
+	Request(context.Context, *Connection) (*http.Request, error)
 	// Response parses the http.Response
 	Response(resp *http.Response) error
 	// The public storage URL - set Internal to true to read
@@ -88,8 +89,8 @@ type v1Auth struct {
 }
 
 // v1 Authentication - make request
-func (auth *v1Auth) Request(c *Connection) (*http.Request, error) {
-	req, err := http.NewRequest("GET", c.AuthUrl, nil)
+func (auth *v1Auth) Request(ctx context.Context, c *Connection) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.AuthUrl, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +142,7 @@ type v2Auth struct {
 }
 
 // v2 Authentication - make request
-func (auth *v2Auth) Request(c *Connection) (*http.Request, error) {
+func (auth *v2Auth) Request(ctx context.Context, c *Connection) (*http.Request, error) {
 	auth.Region = c.Region
 	// Toggle useApiKey if not first run and not OK yet
 	if auth.notFirst && !auth.useApiKeyOk {
@@ -176,7 +177,7 @@ func (auth *v2Auth) Request(c *Connection) (*http.Request, error) {
 		url += "/"
 	}
 	url += "tokens"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}

--- a/auth_v3.go
+++ b/auth_v3.go
@@ -2,6 +2,7 @@ package swift
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -122,7 +123,7 @@ type v3Auth struct {
 	Headers http.Header
 }
 
-func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
+func (auth *v3Auth) Request(ctx context.Context, c *Connection) (*http.Request, error) {
 	auth.Region = c.Region
 
 	var v3i interface{}
@@ -242,7 +243,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 		url += "/"
 	}
 	url += "auth/tokens"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/ncw/swift
-
-go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/ncw/swift
+
+go 1.15

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -6,6 +6,7 @@
 package swift
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -316,7 +317,8 @@ func TestInternalAuthenticate(t *testing.T) {
 	}).Url("/v1.0")
 	defer server.Finished()
 
-	err := c.Authenticate()
+	ctx := context.Background()
+	err := c.AuthenticateWithContext(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +338,7 @@ func TestInternalAuthenticateDenied(t *testing.T) {
 	server.AddCheck(t).Error(401, "DENIED")
 	defer server.Finished()
 	c.UnAuthenticate()
-	err := c.Authenticate()
+	err := c.AuthenticateWithContext(context.Background())
 	if err != AuthorizationFailed {
 		t.Fatal("Expecting AuthorizationFailed", err)
 	}
@@ -351,7 +353,8 @@ func TestInternalAuthenticateBad(t *testing.T) {
 		"X-Storage-Url": PROXY_URL,
 	})
 	defer server.Finished()
-	err := c.Authenticate()
+	ctx := context.Background()
+	err := c.AuthenticateWithContext(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
@@ -360,14 +363,14 @@ func TestInternalAuthenticateBad(t *testing.T) {
 	server.AddCheck(t).Out(Headers{
 		"X-Auth-Token": AUTH_TOKEN,
 	})
-	err = c.Authenticate()
+	err = c.AuthenticateWithContext(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
 	}
 
 	server.AddCheck(t)
-	err = c.Authenticate()
+	err = c.AuthenticateWithContext(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
@@ -377,7 +380,7 @@ func TestInternalAuthenticateBad(t *testing.T) {
 		"X-Storage-Url": PROXY_URL,
 		"X-Auth-Token":  AUTH_TOKEN,
 	})
-	err = c.Authenticate()
+	err = c.AuthenticateWithContext(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +394,7 @@ func testContainerNames(t *testing.T, rx string, expected []string) {
 		"User-Agent":   DefaultUserAgent,
 		"X-Auth-Token": AUTH_TOKEN,
 	}).Tx(rx).Url("/proxy")
-	containers, err := c.ContainerNames(nil)
+	containers, err := c.ContainerNamesWithContext(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +423,7 @@ func TestInternalObjectPutBytes(t *testing.T) {
 		"Content-Type":   "text/plain",
 	}).Rx("12345")
 	defer server.Finished()
-	c.ObjectPutBytes("container", "object", []byte{'1', '2', '3', '4', '5'}, "text/plain")
+	c.ObjectPutBytesWithContext(context.Background(), "container", "object", []byte{'1', '2', '3', '4', '5'}, "text/plain")
 }
 
 func TestInternalObjectPutString(t *testing.T) {
@@ -431,7 +434,7 @@ func TestInternalObjectPutString(t *testing.T) {
 		"Content-Type":   "text/plain",
 	}).Rx("12345")
 	defer server.Finished()
-	c.ObjectPutString("container", "object", "12345", "text/plain")
+	c.ObjectPutStringWithContext(context.Background(), "container", "object", "12345", "text/plain")
 }
 
 func TestSetFromEnv(t *testing.T) {


### PR DESCRIPTION
Resolves #159  #161 

Hi, as suggested in the issue, I'm adding the `*WithContext` functions for all the already existing where it makes sense to pass down the context. Former functions are preserved and calls the new ones using the `context.Background()` to avoid breaking the API of library.

Only breaking change is the change in the `Authenticator` interface where from now on the context is required.
I could add a new function `RequestWithContext` to the interface but that would still break the API if someone is using the `Authenticator` interface. Hopefully it's ok this way.


Tests are passing with original functions used which are now using the `WithContext` in background so hopefully should all work :crossed_fingers: 
