### PR TITLE
Travis-ci: added support for ppc64le & import src path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ arch:
   - amd64
   - ppc64le
 
+go_import_path: github.com/ncw/swift
+
 go:
   - 1.2.x
   - 1.3.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 sudo: false
 
+arch:
+  - amd64
+  - ppc64le
+
 go:
   - 1.2.x
   - 1.3.x
@@ -23,11 +27,31 @@ matrix:
     env: TEST_REAL_SERVER=rackspace
   - go: 1.14.x
     env: TEST_REAL_SERVER=memset
+  - go: 1.14.x
+    arch: ppc64le
+    env: TEST_REAL_SERVER=rackspace
+  - go: 1.14.x
+    arch: ppc64le
+    env: TEST_REAL_SERVER=memset
   allow_failures:
   - go: 1.14.x
     env: TEST_REAL_SERVER=rackspace
   - go: 1.14.x
     env: TEST_REAL_SERVER=memset
+  - go: 1.14.x
+    arch: ppc64le
+    env: TEST_REAL_SERVER=rackspace
+  - go: 1.14.x
+    arch: ppc64le
+    env: TEST_REAL_SERVER=memset
+# Removed unsupported jobs for ppc64le
+  exclude:
+  - go: 1.2.x
+    arch: ppc64le
+  - go: 1.3.x
+    arch: ppc64le
+  - go: 1.4.x
+    arch: ppc64le
 install: go test -i ./...
 script:
   - test -z "$(go fmt ./...)"


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.
Travis-ci log: https://travis-ci.com/github/dthadi3/swift/builds/210359874

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra