### PR TITLE
feat: start v2 major version and add context to functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,52 +8,34 @@ arch:
 go_import_path: github.com/ncw/swift
 
 go:
-  - 1.2.x
-  - 1.3.x
-  - 1.4.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
+  - 1.15.x
   - master
 
 matrix:
   include:
-  - go: 1.14.x
+  - go: 1.15.x
     env: TEST_REAL_SERVER=rackspace
-  - go: 1.14.x
+  - go: 1.15.x
     env: TEST_REAL_SERVER=memset
-  - go: 1.14.x
+  - go: 1.15.x
     arch: ppc64le
     env: TEST_REAL_SERVER=rackspace
-  - go: 1.14.x
+  - go: 1.15.x
     arch: ppc64le
     env: TEST_REAL_SERVER=memset
   allow_failures:
-  - go: 1.14.x
+  - go: 1.15.x
     env: TEST_REAL_SERVER=rackspace
-  - go: 1.14.x
+  - go: 1.15.x
     env: TEST_REAL_SERVER=memset
-  - go: 1.14.x
+  - go: 1.15.x
     arch: ppc64le
     env: TEST_REAL_SERVER=rackspace
-  - go: 1.14.x
+  - go: 1.15.x
     arch: ppc64le
     env: TEST_REAL_SERVER=memset
-# Removed unsupported jobs for ppc64le
-  exclude:
-  - go: 1.2.x
-    arch: ppc64le
-  - go: 1.3.x
-    arch: ppc64le
-  - go: 1.4.x
-    arch: ppc64le
 install: go test -i ./...
 script:
   - test -z "$(go fmt ./...)"

--- a/README.md
+++ b/README.md
@@ -1,52 +1,60 @@
 Swift
 =====
 
-This package provides an easy to use library for interfacing with
-Swift / Openstack Object Storage / Rackspace cloud files from the Go
-Language
+This package provides an easy to use library for interfacing with Swift / Openstack Object Storage / Rackspace cloud
+files from the Go Language
 
 See here for package docs
 
-  http://godoc.org/github.com/ncw/swift
+http://godoc.org/github.com/ncw/swift/v2
 
-[![Build Status](https://api.travis-ci.org/ncw/swift.svg?branch=master)](https://travis-ci.org/ncw/swift) [![GoDoc](https://godoc.org/github.com/ncw/swift?status.svg)](https://godoc.org/github.com/ncw/swift) 
+[![Build Status](https://api.travis-ci.org/ncw/swift.svg?branch=master)](https://travis-ci.org/ncw/swift) [![GoDoc](https://godoc.org/github.com/ncw/swift/v2?status.svg)](https://godoc.org/github.com/ncw/swift/v2)
 
 Install
 -------
 
 Use go to install the library
 
-    go get github.com/ncw/swift
+    go get github.com/ncw/swift/v2
 
 Usage
 -----
 
 See here for full package docs
 
-- http://godoc.org/github.com/ncw/swift
+- http://godoc.org/github.com/ncw/swift/v2
 
 Here is a short example from the docs
+
 ```go
-import "github.com/ncw/swift"
+import "github.com/ncw/swift/v2"
 
 // Create a connection
 c := swift.Connection{
-    UserName: "user",
-    ApiKey:   "key",
-    AuthUrl:  "auth_url",
-    Domain:   "domain",  // Name of the domain (v3 auth only)
-    Tenant:   "tenant",  // Name of the tenant (v2 auth only)
+UserName: "user",
+ApiKey:   "key",
+AuthUrl:  "auth_url",
+Domain:   "domain", // Name of the domain (v3 auth only)
+Tenant:   "tenant", // Name of the tenant (v2 auth only)
 }
 // Authenticate
 err := c.Authenticate()
 if err != nil {
-    panic(err)
+panic(err)
 }
 // List all the containers
 containers, err := c.ContainerNames(nil)
 fmt.Println(containers)
 // etc...
 ```
+
+Migrating from `v1`
+-----
+The library has current major version v2. If you want to migrate from the first version of
+library `github.com/ncw/swift` you have to explicitly add the `/v2` suffix to the imports.
+
+Most of the exported functions were added a new `context.Context` parameter in the `v2`, which you will have to provide
+when migrating.
 
 Additions
 ---------
@@ -56,11 +64,10 @@ The `rs` sub project contains a wrapper for the Rackspace specific CDN Managemen
 Testing
 -------
 
-To run the tests you can either use an embedded fake Swift server
-either use a real Openstack Swift server or a Rackspace Cloud files account.
+To run the tests you can either use an embedded fake Swift server either use a real Openstack Swift server or a
+Rackspace Cloud files account.
 
-When using a real Swift server, you need to set these environment variables
-before running the tests
+When using a real Swift server, you need to set these environment variables before running the tests
 
     export SWIFT_API_USER='user'
     export SWIFT_API_KEY='key'
@@ -99,8 +106,7 @@ Then run the tests with `go test`
 License
 -------
 
-This is free software under the terms of MIT license (check COPYING file
-included in this package).
+This is free software under the terms of MIT license (check COPYING file included in this package).
 
 Contact and support
 -------------------
@@ -161,3 +167,4 @@ Contributors
 - Brandon WELSCH <dev@brandon-welsch.eu>
 - Damien Tournoud <damien@platform.sh>
 - Pedro Kiefer <pedro@kiefer.com.br>
+- Martin Chodur <m.chodur@seznam.cz>

--- a/auth_v3.go
+++ b/auth_v3.go
@@ -2,6 +2,7 @@ package swift
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -122,7 +123,7 @@ type v3Auth struct {
 	Headers http.Header
 }
 
-func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
+func (auth *v3Auth) Request(ctx context.Context, c *Connection) (*http.Request, error) {
 	auth.Region = c.Region
 
 	var v3i interface{}
@@ -242,7 +243,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 		url += "/"
 	}
 	url += "auth/tokens"
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +252,7 @@ func (auth *v3Auth) Request(c *Connection) (*http.Request, error) {
 	return req, nil
 }
 
-func (auth *v3Auth) Response(resp *http.Response) error {
+func (auth *v3Auth) Response(_ context.Context, resp *http.Response) error {
 	auth.Auth = &v3AuthResponse{}
 	auth.Headers = resp.Header
 	err := readJson(resp, auth.Auth)

--- a/example_test.go
+++ b/example_test.go
@@ -4,12 +4,14 @@
 package swift_test
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/ncw/swift"
+	"github.com/ncw/swift/v2"
 )
 
 func ExampleConnection() {
+	ctx := context.Background()
 	// Create a v1 auth connection
 	c := &swift.Connection{
 		// This should be your username
@@ -24,12 +26,12 @@ func ExampleConnection() {
 	}
 
 	// Authenticate
-	err := c.Authenticate()
+	err := c.Authenticate(ctx)
 	if err != nil {
 		panic(err)
 	}
 	// List all the containers
-	containers, err := c.ContainerNames(nil)
+	containers, err := c.ContainerNames(ctx, nil)
 	fmt.Println(containers)
 	// etc...
 
@@ -61,8 +63,8 @@ func ExampleConnection_ObjectsWalk() {
 	defer rollback()
 
 	objects := make([]string, 0)
-	err := c.ObjectsWalk(container, nil, func(opts *swift.ObjectsOpts) (interface{}, error) {
-		newObjects, err := c.ObjectNames(container, opts)
+	err := c.ObjectsWalk(context.Background(), container, nil, func(ctx context.Context, opts *swift.ObjectsOpts) (interface{}, error) {
+		newObjects, err := c.ObjectNames(ctx, container, opts)
 		if err == nil {
 			objects = append(objects, newObjects...)
 		}
@@ -76,23 +78,24 @@ func ExampleConnection_VersionContainerCreate() {
 	defer rollback()
 
 	// Use the helper method to create the current and versions container.
-	if err := c.VersionContainerCreate("cds", "cd-versions"); err != nil {
+	if err := c.VersionContainerCreate(context.Background(), "cds", "cd-versions"); err != nil {
 		fmt.Print(err.Error())
 	}
 }
 
 func ExampleConnection_VersionEnable() {
+	ctx := context.Background()
 	c, rollback := makeConnection(nil)
 	defer rollback()
 
 	// Build the containers manually and enable them.
-	if err := c.ContainerCreate("movie-versions", nil); err != nil {
+	if err := c.ContainerCreate(ctx, "movie-versions", nil); err != nil {
 		fmt.Print(err.Error())
 	}
-	if err := c.ContainerCreate("movies", nil); err != nil {
+	if err := c.ContainerCreate(ctx, "movies", nil); err != nil {
 		fmt.Print(err.Error())
 	}
-	if err := c.VersionEnable("movies", "movie-versions"); err != nil {
+	if err := c.VersionEnable(ctx, "movies", "movie-versions"); err != nil {
 		fmt.Print(err.Error())
 	}
 
@@ -105,5 +108,5 @@ func ExampleConnection_VersionDisable() {
 	defer rollback()
 
 	// Disable versioning on a container.  Note that this does not delete the versioning container.
-	c.VersionDisable("movies")
+	c.VersionDisable(context.Background(), "movies")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/ncw/swift
+module github.com/ncw/swift/v2
+
+go 1.15

--- a/rs/rs_test.go
+++ b/rs/rs_test.go
@@ -2,10 +2,11 @@
 package rs_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
-	"github.com/ncw/swift/rs"
+	"github.com/ncw/swift/v2/rs"
 )
 
 var (
@@ -32,7 +33,7 @@ func TestAuthenticate(t *testing.T) {
 	c.UserName = UserName
 	c.ApiKey = ApiKey
 	c.AuthUrl = AuthUrl
-	err := c.Authenticate()
+	err := c.Authenticate(context.Background())
 	if err != nil {
 		t.Fatal("Auth failed", err)
 	}
@@ -43,14 +44,14 @@ func TestAuthenticate(t *testing.T) {
 
 // Setup
 func TestContainerCreate(t *testing.T) {
-	err := c.ContainerCreate(CONTAINER, nil)
+	err := c.ContainerCreate(context.Background(), CONTAINER, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestCDNEnable(t *testing.T) {
-	headers, err := c.ContainerCDNEnable(CONTAINER, 0)
+	headers, err := c.ContainerCDNEnable(context.Background(), CONTAINER, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -64,14 +65,14 @@ func TestOnReAuth(t *testing.T) {
 	c2.UserName = c.UserName
 	c2.ApiKey = c.ApiKey
 	c2.AuthUrl = c.AuthUrl
-	_, err := c2.ContainerCDNEnable(CONTAINER, 0)
+	_, err := c2.ContainerCDNEnable(context.Background(), CONTAINER, 0)
 	if err != nil {
 		t.Fatalf("Failed to reauthenticate: %v", err)
 	}
 }
 
 func TestCDNMeta(t *testing.T) {
-	headers, err := c.ContainerCDNMeta(CONTAINER)
+	headers, err := c.ContainerCDNMeta(context.Background(), CONTAINER)
 	if err != nil {
 		t.Error(err)
 	}
@@ -81,7 +82,7 @@ func TestCDNMeta(t *testing.T) {
 }
 
 func TestCDNDisable(t *testing.T) {
-	err := c.ContainerCDNDisable(CONTAINER) // files stick in CDN until TTL expires
+	err := c.ContainerCDNDisable(context.Background(), CONTAINER) // files stick in CDN until TTL expires
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +90,7 @@ func TestCDNDisable(t *testing.T) {
 
 // Teardown
 func TestContainerDelete(t *testing.T) {
-	err := c.ContainerDelete(CONTAINER)
+	err := c.ContainerDelete(context.Background(), CONTAINER)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -6,6 +6,7 @@
 package swift
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -316,7 +317,8 @@ func TestInternalAuthenticate(t *testing.T) {
 	}).Url("/v1.0")
 	defer server.Finished()
 
-	err := c.Authenticate()
+	ctx := context.Background()
+	err := c.Authenticate(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +338,7 @@ func TestInternalAuthenticateDenied(t *testing.T) {
 	server.AddCheck(t).Error(401, "DENIED")
 	defer server.Finished()
 	c.UnAuthenticate()
-	err := c.Authenticate()
+	err := c.Authenticate(context.Background())
 	if err != AuthorizationFailed {
 		t.Fatal("Expecting AuthorizationFailed", err)
 	}
@@ -351,7 +353,8 @@ func TestInternalAuthenticateBad(t *testing.T) {
 		"X-Storage-Url": PROXY_URL,
 	})
 	defer server.Finished()
-	err := c.Authenticate()
+	ctx := context.Background()
+	err := c.Authenticate(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
@@ -360,14 +363,14 @@ func TestInternalAuthenticateBad(t *testing.T) {
 	server.AddCheck(t).Out(Headers{
 		"X-Auth-Token": AUTH_TOKEN,
 	})
-	err = c.Authenticate()
+	err = c.Authenticate(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
 	}
 
 	server.AddCheck(t)
-	err = c.Authenticate()
+	err = c.Authenticate(ctx)
 	checkError(t, err, 0, "Response didn't have storage url and auth token")
 	if c.Authenticated() {
 		t.Fatal("Expecting not authenticated")
@@ -377,7 +380,7 @@ func TestInternalAuthenticateBad(t *testing.T) {
 		"X-Storage-Url": PROXY_URL,
 		"X-Auth-Token":  AUTH_TOKEN,
 	})
-	err = c.Authenticate()
+	err = c.Authenticate(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +394,7 @@ func testContainerNames(t *testing.T, rx string, expected []string) {
 		"User-Agent":   DefaultUserAgent,
 		"X-Auth-Token": AUTH_TOKEN,
 	}).Tx(rx).Url("/proxy")
-	containers, err := c.ContainerNames(nil)
+	containers, err := c.ContainerNames(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +423,7 @@ func TestInternalObjectPutBytes(t *testing.T) {
 		"Content-Type":   "text/plain",
 	}).Rx("12345")
 	defer server.Finished()
-	c.ObjectPutBytes("container", "object", []byte{'1', '2', '3', '4', '5'}, "text/plain")
+	c.ObjectPutBytes(context.Background(), "container", "object", []byte{'1', '2', '3', '4', '5'}, "text/plain")
 }
 
 func TestInternalObjectPutString(t *testing.T) {
@@ -431,7 +434,7 @@ func TestInternalObjectPutString(t *testing.T) {
 		"Content-Type":   "text/plain",
 	}).Rx("12345")
 	defer server.Finished()
-	c.ObjectPutString("container", "object", "12345", "text/plain")
+	c.ObjectPutString(context.Background(), "container", "object", "12345", "text/plain")
 }
 
 func TestSetFromEnv(t *testing.T) {


### PR DESCRIPTION
Resolves #159 #161
Replaces #162 

As discussed here https://github.com/ncw/swift/pull/162#issuecomment-751459979 I'm bumping the new `v2` major version in the go.mod and adding context to all the functions without changing their names.

PTAL @ncw 