### PR TITLE
Path unescape the data return in the X-Object-Manifest header

### DIFF
--- a/dlo.go
+++ b/dlo.go
@@ -46,7 +46,11 @@ func (c *Connection) DynamicLargeObjectMove(ctx context.Context, srcContainer st
 		return err
 	}
 
-	segmentContainer, segmentPath := parseFullPath(headers["X-Object-Manifest"])
+	segmentContainer, segmentPath, err := parseFullPath(headers["X-Object-Manifest"])
+	if err != nil {
+		return err
+	}
+
 	if err := c.createDLOManifest(ctx, dstContainer, dstObjectName, segmentContainer+"/"+segmentPath, info.ContentType, sanitizeLargeObjectMoveHeaders(headers)); err != nil {
 		return err
 	}

--- a/slo.go
+++ b/slo.go
@@ -164,7 +164,10 @@ func (c *Connection) getAllSLOSegments(ctx context.Context, container, path stri
 
 	json.Unmarshal(content, &segmentList)
 	for _, segment := range segmentList {
-		segmentContainer, segPath = parseFullPath(segment.Name[1:])
+		segmentContainer, segPath, err = parseFullPath(segment.Name[1:])
+		if err != nil {
+			return "", nil, err
+		}
 		segments = append(segments, Object{
 			Name:  segPath,
 			Bytes: segment.Bytes,


### PR DESCRIPTION
This fixes an rclone bug 5180 where openstack/swift returned
an url encoded path in the X-Object-Manifest header.

This then caused problems when resolving the segments.