### PR TITLE
Fix races related to the way how authLock is implemented and used

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -126,7 +126,7 @@ type Connection struct {
 	Expires    time.Time // time the token expires, may be Zero if unknown
 	client     *http.Client
 	Auth       Authenticator `json:"-" xml:"-"` // the current authenticator
-	authLock   *sync.Mutex   // lock when R/W StorageUrl, AuthToken, Auth
+	authLock   sync.Mutex    // lock when R/W StorageUrl, AuthToken, Auth
 	// swiftInfo is filled after QueryInfo is called
 	swiftInfo SwiftInfo
 }
@@ -459,9 +459,6 @@ func (c *Connection) setDefaults() {
 // If you don't call it before calling one of the connection methods
 // then it will be called for you on the first access.
 func (c *Connection) Authenticate(ctx context.Context) (err error) {
-	if c.authLock == nil {
-		c.authLock = &sync.Mutex{}
-	}
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 	return c.authenticate(ctx)
@@ -584,9 +581,6 @@ func (c *Connection) UnAuthenticate() {
 //
 // Doesn't actually check the credentials against the server.
 func (c *Connection) Authenticated() bool {
-	if c.authLock == nil {
-		c.authLock = &sync.Mutex{}
-	}
 	c.authLock.Lock()
 	defer c.authLock.Unlock()
 	return c.authenticated()


### PR DESCRIPTION
### 1. Allocate authLock as part of Connection

Previously when Authenticate() or Authenticated() was called simultaneously from several goroutines authLock was initialized in racy manner. Such code is not allowed by Go Memory Model and sometimes crashes.

### 2. Introduce GetStorageUrl() method

Access to StorageUrl without taking authLock is racy. New method GetStorageUrl() is added for getting StorageLock in race-free manner. Methods where StorageUrl was accessed without lock (QueryInfo() and ObjectTempUrl()) are updated.