### PR TITLE
Implement federated (v3oidcaccesstoken) auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -10,6 +10,10 @@ import (
 	"time"
 )
 
+// Method signatures for Authenticator and TwoStageAuthenticator
+type AuthRequestGenerator func(context.Context, *Connection) (*http.Request, error)
+type AuthResponseHandler func(context.Context, *http.Response) error
+
 // Auth defines the operations needed to authenticate with swift
 //
 // This encapsulates the different authentication schemes in use
@@ -25,6 +29,16 @@ type Authenticator interface {
 	Token() string
 	// The CDN url if available
 	CdnUrl() string
+}
+
+// TwoStageAuthenticator is used for authentication using two requests, like with v3oidcaccesstoken
+type TwoStageAuthenticator interface {
+	Authenticator
+
+	// PrelimRequest returns a request if the authenticator needs to do a request before the main auth request
+	PrelimRequest(context.Context, *Connection) (*http.Request, error)
+	// PrelimResponse parses the response to a PrelimRequest
+	PrelimResponse(context.Context, *http.Response) error
 }
 
 // Expireser is an optional interface to read the expiration time of the token

--- a/swift.go
+++ b/swift.go
@@ -118,6 +118,10 @@ type Connection struct {
 	TenantDomain                string            // Name of the tenant's domain (v3 auth only), only needed if it differs from the user domain
 	TenantDomainId              string            // Id of the tenant's domain (v3 auth only), only needed if it differs the from user domain
 	TrustId                     string            // Id of the trust (v3 auth only)
+	ProjectId                   string            // Id of the project (v3 federated auth only)
+	IdentityProvider            string            // Identity provider (v3 federated auth only)
+	AuthProtocol                string            // AuthProtocol, e.g. 'openid'  (v3 federated auth only)
+	AccessToken                 string            // Access token (v3 federated auth only)
 	Transport                   http.RoundTripper `json:"-" xml:"-"` // Optional specialised http.Transport (eg. for Google Appengine)
 	// These are filled in after Authenticate is called as are the defaults for above
 	StorageUrl string
@@ -257,6 +261,12 @@ func (c *Connection) ApplyEnvironment() (err error) {
 		{&c.TrustId, "OS_TRUST_ID"},
 		{&c.StorageUrl, "OS_STORAGE_URL"},
 		{&c.AuthToken, "OS_AUTH_TOKEN"},
+
+		{&c.ProjectId, "OS_PROJECT_ID"},
+		{&c.AccessToken, "OS_ACCESS_TOKEN"},
+		{&c.IdentityProvider, "OS_IDENTITY_PROVIDER"},
+		{&c.AuthProtocol, "OS_PROTOCOL"},
+
 		// v1 auth alternatives
 		{&c.ApiKey, "ST_KEY"},
 		{&c.UserName, "ST_USER"},
@@ -471,27 +481,12 @@ func (c *Connection) Authenticate(ctx context.Context) (err error) {
 	return c.authenticate(ctx)
 }
 
-// Internal implementation of Authenticate
-//
-// Call with authLock held
-func (c *Connection) authenticate(ctx context.Context) (err error) {
-	c.setDefaults()
-
-	// Flush the keepalives connection - if we are
-	// re-authenticating then stuff has gone wrong
-	flushKeepaliveConnections(c.Transport)
-
-	if c.Auth == nil {
-		c.Auth, err = newAuth(c)
-		if err != nil {
-			return
-		}
-	}
-
+// executeRequestResponsePair generates an auth request using reqGen and handles the response using reqHandler
+func (c *Connection) executeRequestResponsePair(ctx context.Context, reqGen AuthRequestGenerator, reqHandler AuthResponseHandler) (err error) {
 	retries := 1
 again:
 	var req *http.Request
-	req, err = c.Auth.Request(ctx, c)
+	req, err = reqGen(ctx, c)
 	if err != nil {
 		return
 	}
@@ -519,11 +514,41 @@ again:
 			}
 			return
 		}
-		err = c.Auth.Response(ctx, resp)
+		return reqHandler(ctx, resp)
+	}
+	return
+}
+
+// Internal implementation of Authenticate
+//
+// Call with authLock held
+func (c *Connection) authenticate(ctx context.Context) (err error) {
+	c.setDefaults()
+
+	// Flush the keepalives connection - if we are
+	// re-authenticating then stuff has gone wrong
+	flushKeepaliveConnections(c.Transport)
+
+	if c.Auth == nil {
+		c.Auth, err = newAuth(c)
 		if err != nil {
 			return
 		}
 	}
+
+	// handle optional authentication stage
+	if prelimAuth, needsPrelimReq := c.Auth.(TwoStageAuthenticator); needsPrelimReq {
+		err = c.executeRequestResponsePair(ctx, prelimAuth.PrelimRequest, prelimAuth.PrelimResponse)
+		if err != nil {
+			return
+		}
+	}
+
+	err = c.executeRequestResponsePair(ctx, c.Auth.Request, c.Auth.Response)
+	if err != nil {
+		return
+	}
+
 	if customAuth, isCustom := c.Auth.(CustomEndpointAuthenticator); isCustom && c.EndpointType != "" {
 		c.StorageUrl = customAuth.StorageUrlForEndpoint(c.EndpointType)
 	} else {


### PR DESCRIPTION
v3oidcaccesstoken requires two authentication requests:
1. Retrieving an unscoped token using an oidc access token
2. Retrieving a scoped token using the unscoped token (already implemented in v3auth)

Change summary:
 - Extracted method for auth request handling
 - Added missing fields to Connection, e.g. IdentityProvider
   - Added mappings to the relevant openstack environment variables
 - Added interface TwoStageAuthenticator
 - Implemented PrelimRequest and PrelimResponse for v3auth

Sadly I saw no reasonable way to test these changes, but I'm completely
open to suggestions. This includes the way I extended the authentication
handling, which may or may not be optimal.

These changes are a follow up to this forum thread: https://forum.rclone.org/t/swift-env-auth-true-env-os-access-token-http-error-404-404-not-found/22520