### PR TITLE
Support non-standard time format

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1114,16 +1114,13 @@ func (c *Connection) Objects(ctx context.Context, container string, opts *Object
 			object.ContentType = "application/directory"
 		}
 		if object.ServerLastModified != "" {
-			// 2012-11-11T14:49:47.887250
+			// e.g. 2012-11-11T14:49:47, 2012-11-11T14:49:47Z, 2012-11-11T14:49:47.887250, or 2012-11-11T14:49:47.887250Z
+			// Remove the Z suffix and fractional seconds if present. This then keeps it consistent with Object which
+			// can only return timestamps accurate to 1 second
 			//
-			// Remove fractional seconds if present. This
-			// then keeps it consistent with Object
-			// which can only return timestamps accurate
-			// to 1 second
-			//
-			// The TimeFormat will parse fractional
-			// seconds if desired though
-			datetime := strings.SplitN(object.ServerLastModified, ".", 2)[0]
+			// The TimeFormat will parse fractional seconds if desired though
+			lastModified := strings.TrimSuffix(object.ServerLastModified, "Z")
+			datetime := strings.SplitN(lastModified, ".", 2)[0]
 			object.LastModified, err = time.Parse(TimeFormat, datetime)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
We are working with a Swift backend server that returns `last_modified` formatted as `2022-08-18T04:02:34Z` instead of `2022-08-18T04:02:34` . Because of that, the `Objects()` call returns the following error:
```
parsing time "2022-08-18T04:02:34Z": extra text: "Z"
```

As per [the OpenStack Storage API reference](https://docs.openstack.org/api-ref/object-store/index.html?expanded=show-container-details-and-list-objects-detail#objects), 
> The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):

`2022-08-18T04:02:34Z` appears to be a valid ISO 8601 format according to wikipedia. 

~~The easiest way to support it is probably to make time format a setting that can be changed by the user. This PR does that.~~

This removes the `Z` suffix from `object.ServerLastModified` before using it.

Please review.

Thanks!
