### PR TITLE
Support for parsing json in ObjectNames()

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1066,7 +1066,20 @@ func (c *Connection) ObjectNames(ctx context.Context, container string, opts *Ob
 	if err != nil {
 		return nil, err
 	}
-	return readLines(resp)
+	switch resp.Header.Get("Content-Type") {
+	case "application/json":
+		var objects []Object
+		err := readJson(resp, &objects)
+
+		var names []string
+		for _, obj := range objects {
+			names = append(names, obj.Name)
+		}
+
+		return names, err
+	default:
+		return readLines(resp)
+	}
 }
 
 // Object contains information about an object


### PR DESCRIPTION
fix https://github.com/ncw/swift/issues/181

It does not contain implementations for other types.

However, if a request is made with json format, the body of the received resp is parsed and the name list is returned.