### PR TITLE
Added quota info (total bytes and objects count) support for containers.

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -920,9 +920,11 @@ func (c *Connection) ContainerNames(ctx context.Context, opts *ContainersOpts) (
 
 // Container contains information about a container
 type Container struct {
-	Name  string // Name of the container
-	Count int64  // Number of objects in the container
-	Bytes int64  // Total number of bytes used in the container
+	Name       string // Name of the container
+	Count      int64  // Number of objects in the container
+	Bytes      int64  // Total number of bytes used in the container
+	QuotaCount int64  // Maximum object count of the container. 0 if not available
+	QuotaBytes int64  // Maximum size of the container, in bytes. 0 if not available
 }
 
 // Containers returns a slice of structures with full information as
@@ -1350,6 +1352,9 @@ func (c *Connection) Container(ctx context.Context, container string) (info Cont
 	if info.Count, err = getInt64FromHeader(resp, "X-Container-Object-Count"); err != nil {
 		return
 	}
+	// optional headers
+	info.QuotaBytes, _ = getInt64FromHeader(resp, "X-Container-Meta-Quota-Bytes")
+	info.QuotaCount, _ = getInt64FromHeader(resp, "X-Container-Meta-Quota-Count")
 	return
 }
 


### PR DESCRIPTION
Swift protocol allows to retrieve quota info for a container (see [openstack doc](https://docs.openstack.org/api-ref/object-store/#show-container-metadata) ). This commit is to get those additional data (if available). 

This is useful to enhance [rclone about](https://rclone.org/commands/rclone_about/) command when used with swift implementations that provide quota info  (Ex. [Blomp storage](https://www.blomp.com/cloud-storage/)).