### PR TITLE
Add support for Token field to enable v3 token authentication

### DIFF
--- a/auth_v3.go
+++ b/auth_v3.go
@@ -179,6 +179,9 @@ func (auth *v3Auth) Request(ctx context.Context, c *Connection) (*http.Request, 
 			Secret: c.ApplicationCredentialSecret,
 			User:   user,
 		}
+	} else if c.Token != "" {
+		v3.Auth.Identity.Methods = []string{v3AuthMethodToken}
+		v3.Auth.Identity.Token = &v3AuthToken{Id: c.Token}
 	} else if c.UserName == "" && c.UserId == "" {
 		v3.Auth.Identity.Methods = []string{v3AuthMethodToken}
 		v3.Auth.Identity.Token = &v3AuthToken{Id: c.ApiKey}

--- a/swift.go
+++ b/swift.go
@@ -103,6 +103,7 @@ type Connection struct {
 	ApplicationCredentialId     string            // Application Credential ID
 	ApplicationCredentialName   string            // Application Credential Name
 	ApplicationCredentialSecret string            // Application Credential Secret
+	Token                       string            // Token used for v3token authentication
 	AuthUrl                     string            // Auth URL
 	Retries                     int               // Retries on error (default is 3)
 	UserAgent                   string            // Http User agent (default goswift/1.0)


### PR DESCRIPTION
This adds a new `Token` field to explicitly support v3 token authentication, improving clarity by separating it from the existing `ApiKey` usage. The existing behavior with `ApiKey` remains unchanged for backward compatibility.