### PR TITLE
Avoid reattempting authentication for auth versions where it has no effect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 test-env*
 junk/
+.idea

--- a/auth.go
+++ b/auth.go
@@ -25,6 +25,8 @@ type Authenticator interface {
 	Token() string
 	// The CDN url if available
 	CdnUrl() string
+	// Is there a point in reattempting auth in this scheme?
+	ShouldReattemptAuth() bool
 }
 
 // Expireser is an optional interface to read the expiration time of the token
@@ -128,6 +130,12 @@ func (auth *v1Auth) Token() string {
 // v1 Authentication - read cdn url
 func (auth *v1Auth) CdnUrl() string {
 	return auth.Headers.Get("X-CDN-Management-Url")
+}
+
+// v1 Authentication - should reattempt login
+func (auth *v1Auth) ShouldReattemptAuth() bool {
+	// No point in reattempting the login in case of auth failure, the expected result is the same
+	return false
 }
 
 // ------------------------------------------------------------
@@ -259,6 +267,12 @@ func (auth *v2Auth) Expires() time.Time {
 // v2 Authentication - read cdn url
 func (auth *v2Auth) CdnUrl() string {
 	return auth.endpointUrl("rax:object-cdn", EndpointTypePublic)
+}
+
+// v2 Authentication - should reattempt login
+func (auth *v2Auth) ShouldReattemptAuth() bool {
+	// As part of the Rackspace auth workaround authentication sometimes needs to be retried
+	return true
 }
 
 // ------------------------------------------------------------

--- a/auth_v3.go
+++ b/auth_v3.go
@@ -301,3 +301,8 @@ func (auth *v3Auth) Expires() time.Time {
 func (auth *v3Auth) CdnUrl() string {
 	return ""
 }
+
+func (auth *v3Auth) ShouldReattemptAuth() bool {
+	// No point in reattempting the login in case of auth failure, the expected result is the same
+	return false
+}

--- a/swift.go
+++ b/swift.go
@@ -494,7 +494,8 @@ func (c *Connection) authenticate(ctx context.Context) (err error) {
 		}
 	}
 
-	retries := 1
+	shouldReattempt := c.Auth.ShouldReattemptAuth()
+
 again:
 	var req *http.Request
 	req, err = c.Auth.Request(ctx, c)
@@ -519,8 +520,8 @@ again:
 			// Try again for a limited number of times on
 			// AuthorizationFailed or BadRequest. This allows us
 			// to try some alternate forms of the request
-			if (err == AuthorizationFailed || err == BadRequest) && retries > 0 {
-				retries--
+			if (err == AuthorizationFailed || err == BadRequest) && shouldReattempt {
+				shouldReattempt = false
 				goto again
 			}
 			return

--- a/swift_internal_test.go
+++ b/swift_internal_test.go
@@ -335,19 +335,34 @@ func TestInternalAuthenticate(t *testing.T) {
 	}
 }
 
-func TestInternalAuthenticateDenied(t *testing.T) {
+func setVersion(version int) {
+	c.AuthVersion = version
+	c.Auth = nil
+}
+
+func TestInternalAuthenticateDeniedv2(t *testing.T) {
 	server.AddCheck(t).Error(400, "Bad request")
 	server.AddCheck(t).Error(401, "DENIED")
 	defer server.Finished()
+	defer setVersion(c.AuthVersion)
+	setVersion(2)
 	c.UnAuthenticate()
 	err := c.Authenticate(context.Background())
 	if err != AuthorizationFailed {
 		t.Fatal("Expecting AuthorizationFailed", err)
 	}
-	// FIXME
-	// if c.Authenticated() {
-	// 	t.Fatal("Expecting not authenticated")
-	// }
+}
+
+func TestInternalAuthenticateDeniedv3(t *testing.T) {
+	server.AddCheck(t).Error(401, "DENIED")
+	defer server.Finished()
+	defer setVersion(c.AuthVersion)
+	setVersion(3)
+	c.UnAuthenticate()
+	err := c.Authenticate(context.Background())
+	if err != AuthorizationFailed {
+		t.Fatal("Expecting AuthorizationFailed", err)
+	}
 }
 
 func TestInternalAuthenticateBad(t *testing.T) {


### PR DESCRIPTION
There are circumstances where the automatic authentication retry causes confusion and unexpected behaviour.

For example when the password is entered by a human and mistyped. If the underlying authentication system causes the user to be blocked after X attempts this will happen sooner than expected (after X/2 attempts).

This PR limits the retry to only happen for versions where it may have any actual positive effect (v2).